### PR TITLE
refactor(collapse): remove dependency about rc-collapse

### DIFF
--- a/src/components/collapse/base.tsx
+++ b/src/components/collapse/base.tsx
@@ -1,0 +1,27 @@
+import {
+    prefixClaName,
+    getBEMElement,
+    getBEMModifier,
+} from 'mo/common/className';
+
+export const defaultCollapseClassName = prefixClaName('collapse');
+export const collapseItemClassName = getBEMElement(
+    defaultCollapseClassName,
+    'item'
+);
+export const collapseActiveClassName = getBEMModifier(
+    defaultCollapseClassName,
+    'active'
+);
+export const collapseHeaderClassName = getBEMElement(
+    defaultCollapseClassName,
+    'header'
+);
+export const collapseContentClassName = getBEMElement(
+    defaultCollapseClassName,
+    'content'
+);
+export const collapseExtraClassName = getBEMElement(
+    defaultCollapseClassName,
+    'extra'
+);

--- a/src/components/collapse/style.scss
+++ b/src/components/collapse/style.scss
@@ -1,119 +1,80 @@
 @import 'mo/style/common';
 
-#{$collapse} {
-    font-size: 13px;
-    height: 100%;
+$collapse__extra: #{$collapse}__extra;
 
-    &__content--padding {
-        padding: 10px;
+#{$collapse} {
+    height: 100%;
+    position: relative;
+
+    &:focus-within {
+        #{$collapse__extra} {
+            opacity: 1;
+        }
     }
 
-    #{$rcCollapse} {
-        background-color: inherit;
+    &__item {
+        border-bottom: 1px solid var(--sideBarSectionHeader-border);
         display: flex;
         flex-direction: column;
-        height: 100%;
+        line-height: 22px;
+        overflow: hidden;
+        position: absolute;
+        transition: top ease-in-out 0.2s, height ease-in-out 0.2s;
+        width: 100%;
 
-        &-anim-active {
-            transition: height 0.2s ease-out;
-        }
-
-        &-item {
-            border-bottom: 1px solid var(--sideBarSectionHeader-border);
-
-            &-active {
-                overflow: hidden;
-
-                &:not(.empty) {
-                    flex: 1;
-                }
-
-                &:hover {
-                    #{$collapse}__toolbar {
-                        opacity: 1;
-                    }
-                }
-            }
-
-            &:last-child {
-                border-bottom-color: transparent;
-                #{$rcCollapse}-content {
-                    border-radius: 0 0 3px 3px;
-                }
-            }
-
-            // empty content do not unfold
-            &.empty {
-                #{$rcCollapse}-content {
-                    height: 0;
-                    min-height: 0;
-                }
+        &:hover {
+            #{$collapse__extra} {
+                opacity: 1;
             }
         }
 
-        &-header {
-            align-items: center;
-            border: 1px solid transparent;
-            cursor: pointer;
-            display: flex;
-            font-size: 11px;
-            font-weight: bold;
-            height: 22px;
-            outline: none;
-            padding: 1px 2px;
-            user-select: none;
+        &:last-child {
+            border-bottom-color: transparent;
+        }
+    }
 
-            &-collapsable-only {
-                cursor: default;
-            }
+    &--active {
+        overflow: auto;
+    }
 
-            &-text {
-                cursor: pointer;
-            }
+    &__header {
+        align-items: center;
+        border: 1px solid transparent;
+        cursor: pointer;
+        display: flex;
+        font-size: 11px;
+        font-weight: bold;
+        height: 22px;
+        outline: none;
+        padding: 1px 2px;
+        user-select: none;
 
-            &:focus {
-                border-color: var(--list-focusOutline);
+        &:focus {
+            border-color: var(--list-focusOutline);
+        }
+    }
 
-                #{$collapse}__toolbar {
-                    opacity: 1;
-                }
+    &__extra {
+        margin: 0 0 0 auto;
+        opacity: 0;
+
+        #{$actionBar}__label.codicon {
+            color: var(--activityBar-inactiveForeground);
+            height: inherit;
+            line-height: inherit;
+
+            &:hover {
+                color: var(--activityBar-activeBorder);
             }
         }
+    }
 
-        &-extra {
-            margin: 0 0 0 auto;
+    &__content {
+        border: 1px solid transparent;
+        flex: 1;
 
-            #{$collapse}__toolbar {
-                opacity: 0;
-            }
-
-            #{$actionBar}__label.codicon {
-                color: var(--activityBar-inactiveForeground);
-                height: inherit;
-                line-height: inherit;
-
-                &:hover {
-                    color: var(--activityBar-activeBorder);
-                }
-            }
-        }
-
-        &-content {
-            // transition do not support a non-specific value like auto、100% and so on
-            // TODO: so set a specific value just for height transition
-            height: 500px;
-            min-height: calc(100% - 24px);
-            overflow: auto;
-
-            &-box {
-                font-size: 12px;
-                height: 100%;
-            }
-
-            &-inactive {
-                height: 0;
-                min-height: 0;
-            }
+        &:focus {
+            border-color: var(--list-focusOutline);
         }
     }
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,7 +16,7 @@ export type { IButtonProps } from './button';
 export { Checkbox } from './checkbox';
 export type { ICheckboxProps } from './checkbox';
 
-export { Collapse, CollapsePanel } from './collapse';
+export { Collapse } from './collapse';
 export type { ICollapseProps } from './collapse';
 
 export { useContextMenu } from './contextMenu';


### PR DESCRIPTION
### 简介
- 基于 `rc-collapse` 实现的 explorer panel 无法完全实现所需要的交互体验，所以考虑将底层的 `collapse` 组件重构，原生手写一套 `collapse` 不再基于 `rc-collapse`

### 主要变更
- 提取所用到的 className 到 `base.ts` 中
- 优化重构 `collapse` 的 DOM 结构，目前是 `mo-collapse -> mo-collapse__item -> mo-collapse__header mo-collapse__content`
- 基于 flex 的布局无法满足交互，参考了 vscode 的设计，通过 `absolute` 的定位并计算当前 panel 的 height 和 top
    -  通过 `calcPosition` 该方法，每次渲染都去计算当前 panel 的位置，大部分逻辑在注释中已经写出
    -  主要思路为：
        - 首先通过当前 panel 的 active 和 empty 的状态来计算出高度，当前的 panel 如果是 inactive 的状态或者是 empty 即空内容的话，则高度为默认高度。如果是 active 并且内容不是空的话，就去计算当前 panel 可以占用的高度，需要注意的是，这里的高度需要去除掉 inactive 和 empty 的那些 panels 的默认高度，然后剩下的高度平分。
        - 然后，计算当前 panel 的 top 值。通过 `_cachePosition` 数组将之前的 panel 所得到的结果缓存一下，每次重渲染情况数组，然后便利当前 panel 之前的 panels，只需要计算出之前的 panels 的高度总和就是当前 panel 的 top 值
    - `_cacheWrapperHeight` 该值用于缓存当前 wrapper 的高度，由于切换到 `testPane` 之后 `addPanel` 会触发重渲染，而此时处于 testPane 而没有 `Explorer` 的话，`getBoundingClientRect` 会获取到空的高度，所以缓存一下防止高度丢失
    - 通过监听 `resize` 事件，对 `activePanelKeys` 做一次简单的赋值是为了触发重渲染，让页面可以重新计算 panel 的位置


 ### Related Issue

Resolved #178 