### PR TITLE
fix: add the built-in addons for the searchPane

### DIFF
--- a/src/controller/search/search.tsx
+++ b/src/controller/search/search.tsx
@@ -14,6 +14,9 @@ import {
     SEARCH_REPLACE_ALL_COMMAND_ID,
     SEARCH_ACTIVITY_ITEM,
     builtInSearchActivityItem,
+    builtInHeaderToolbar,
+    builtInSearchAddons,
+    builtInReplaceAddons,
 } from 'mo/model/workbench/search';
 import {
     ActivityBarService,
@@ -97,6 +100,12 @@ export class SearchController extends Controller implements ISearchController {
         };
 
         this.sidebarService.push(searchSidePane);
+
+        this.searchService.setState({
+            headerToolBar: builtInHeaderToolbar(),
+            searchAddons: builtInSearchAddons(),
+            replaceAddons: builtInReplaceAddons(),
+        });
 
         this.activityBarService.addBar(builtInSearchActivityItem());
 


### PR DESCRIPTION
# Description
 - 添加之前重构国际化时不小心删掉的搜索 addons 按钮
