### PR TITLE
fix(collapse): fix calc content height failed because of height: 100%

### DIFF
--- a/src/components/collapse/index.tsx
+++ b/src/components/collapse/index.tsx
@@ -112,9 +112,13 @@ export function Collapse(props: ICollapseProps) {
             const dom = select<HTMLElement>(
                 `.${collapseItemClassName}[data-content='${panel.id}']`
             );
-            if (dom) {
+            const contentDom = select<HTMLElement>(
+                `.${collapseContentClassName}[data-content='${panel.id}']`
+            );
+            if (dom && contentDom) {
                 dom.style.height = `${height}px`;
                 dom.style.top = `${top}px`;
+                contentDom.style.height = `${height - HEADER_HEIGTH - 2}px`;
             }
         });
     }, [filterData]);

--- a/src/components/collapse/style.scss
+++ b/src/components/collapse/style.scss
@@ -71,7 +71,6 @@ $collapse__extra: #{$collapse}__extra;
 
     &__content {
         border: 1px solid transparent;
-        height: calc(100% - 2px);
         width: calc(100% - 3px);
 
         &:focus {


### PR DESCRIPTION
### 简介
- 修复 collapse panel 高度计算错误的情况，主要原因是因为当设置了 content 的 `height: 100%` 以后，会导致 `getBoundingClientRect` 拿到的高度有问题，所以不能够通过设置 `height:100%` 来撑高内容的高度


### 主要变更
- 移除 content 的 height 样式
- 通过给 contentDom 直接赋值高度的方式来撑高度