### PR TITLE
refactor: improve activitybar & sidebar

### DIFF
--- a/src/controller/activityBar.ts
+++ b/src/controller/activityBar.ts
@@ -25,8 +25,14 @@ import {
 import { CommandQuickAccessViewAction } from 'mo/monaco/quickAccessViewAction';
 import { IMonacoService, MonacoService } from 'mo/monaco/monacoService';
 export interface IActivityBarController {
-    onSelect?: (key: string, item?: IActivityBarItem) => void;
-    onClick?: (event: React.MouseEvent, item: IActivityBarItem) => void;
+    /**
+     * Called when activity bar item is clicked
+     */
+    onClick?: (selectedKey: string, selectedNode: IActivityBarItem) => void;
+    /**
+     * Called when activity bar item which is not global is changed
+     */
+    onChange?: (prevSelected?: string, nextSelected?: string) => void;
     onContextMenuClick?: (
         e: React.MouseEvent,
         item: IMenuItemProps | undefined
@@ -50,23 +56,18 @@ export class ActivityBarController
         this.menuBarController = container.resolve(MenuBarController);
     }
 
-    public readonly onSelect = (
-        key: string,
-        item?: IActivityBarItem | undefined
+    public readonly onClick = (
+        selectedKey: string,
+        selctedNode: IActivityBarItem
     ) => {
-        if (item && item.type !== 'global') {
-            this.activityBarService.setState({
-                selected: key,
-            });
-        }
-        this.emit(ActivityBarEvent.Selected, key, item);
+        this.emit(ActivityBarEvent.OnClick, selectedKey, selctedNode);
     };
 
-    public readonly onClick = (
-        event: React.MouseEvent,
-        item: IActivityBarItem
+    public readonly onChange = (
+        prevSelected?: string,
+        nextSelected?: string
     ) => {
-        this.emit(ActivityBarEvent.OnClick, event, item);
+        this.emit(ActivityBarEvent.OnChange, prevSelected, nextSelected);
     };
 
     private gotoQuickCommand() {

--- a/src/controller/search/search.tsx
+++ b/src/controller/search/search.tsx
@@ -2,7 +2,6 @@ import 'reflect-metadata';
 import { Controller } from 'mo/react/controller';
 import { container, singleton } from 'tsyringe';
 import { connect } from 'mo/react';
-import { IActivityBarItem } from 'mo/model';
 import * as React from 'react';
 import { SearchPanel } from 'mo/workbench/sidebar/search';
 import { IActionBarItemProps } from 'mo/components/actionBar';
@@ -12,7 +11,6 @@ import {
     SEARCH_REGULAR_EXPRESSION_COMMAND_ID,
     SEARCH_PRESERVE_CASE_COMMAND_ID,
     SEARCH_REPLACE_ALL_COMMAND_ID,
-    SEARCH_ACTIVITY_ITEM,
     builtInSearchActivityItem,
     builtInHeaderToolbar,
     builtInSearchAddons,
@@ -92,14 +90,12 @@ export class SearchController extends Controller implements ISearchController {
         };
 
         const searchSidePane = {
-            id: 'searchPane',
+            id: builtInSearchActivityItem().id,
             title: 'SEARCH',
             render() {
                 return <SearchPanelView {...searchEvent} />;
             },
         };
-
-        this.sidebarService.push(searchSidePane);
 
         this.searchService.setState({
             headerToolBar: builtInHeaderToolbar(),
@@ -107,15 +103,8 @@ export class SearchController extends Controller implements ISearchController {
             replaceAddons: builtInReplaceAddons(),
         });
 
+        this.sidebarService.addPane(searchSidePane);
         this.activityBarService.addBar(builtInSearchActivityItem());
-
-        this.activityBarService.onSelect((e, item: IActivityBarItem) => {
-            if (item.id === SEARCH_ACTIVITY_ITEM) {
-                this.sidebarService.setState({
-                    current: searchSidePane.id,
-                });
-            }
-        });
     }
 
     public readonly validateValue = (value: string) => {

--- a/src/extensions/activityBar/index.ts
+++ b/src/extensions/activityBar/index.ts
@@ -8,5 +8,19 @@ export const ExtendsActivityBar: IExtension = {
         const { data = [], contextMenu = [] } = builtInActivityBar();
         molecule.activityBar.addBar(data);
         molecule.activityBar.addContextMenu(contextMenu);
+
+        molecule.activityBar.onChange((pre, cur) => {
+            if (pre === cur) {
+                molecule.activityBar.setActive(undefined);
+                molecule.layout.setSideBarHidden();
+            } else {
+                molecule.activityBar.setActive(cur);
+                molecule.sidebar.setActive(cur);
+                const { sideBar } = molecule.layout.getState();
+                if (sideBar.hidden) {
+                    molecule.layout.setSideBarHidden();
+                }
+            }
+        });
     },
 };

--- a/src/model/workbench/activityBar.ts
+++ b/src/model/workbench/activityBar.ts
@@ -6,11 +6,8 @@ import { localize } from 'mo/i18n/localize';
  * The activity bar event definition
  */
 export enum ActivityBarEvent {
-    /**
-     * Selected an activity bar
-     */
-    Selected = 'activityBar.selected',
     OnClick = 'activityBar.onClick',
+    OnChange = 'activityBar.onChange',
     /**
      * Activity bar data changed
      */

--- a/src/services/workbench/activityBarService.ts
+++ b/src/services/workbench/activityBarService.ts
@@ -14,7 +14,18 @@ import { IMenuItemProps } from 'mo/components/menu';
 
 export interface IActivityBarService extends Component<IActivityBar> {
     reset(): void;
-    addBar(data: IActivityBarItem | IActivityBarItem[]): void;
+    /**
+     *
+     * @param isActive If provide, Activity Bar will set data active automatically. Only works in one data
+     */
+    addBar(
+        data: IActivityBarItem | IActivityBarItem[],
+        isActive?: boolean
+    ): void;
+    /**
+     * set active bar
+     */
+    setActive(id?: string): void;
     remove(id: string): void;
     toggleBar(id?: string): void;
     updateContextMenuCheckStatus(id?: string): void;
@@ -24,8 +35,13 @@ export interface IActivityBarService extends Component<IActivityBar> {
      * Add click event listener
      * @param callback
      */
-    onClick(callback: (key: React.MouseEvent, item: IActivityBarItem) => void);
-    onSelect(callback: (key: React.MouseEvent, item: IActivityBarItem) => void);
+    onClick(callback: (selectedKey: string, item: IActivityBarItem) => void);
+    /**
+     * Called when activity bar item which is not global is changed
+     */
+    onChange(
+        callback: (prevSelectedKey?: string, nextSelectedKey?: string) => void
+    );
 }
 
 @singleton()
@@ -38,6 +54,11 @@ export class ActivityBarService
         super();
         this.state = container.resolve(ActivityBarModel);
     }
+    public setActive(id?: string) {
+        this.setState({
+            selected: id,
+        });
+    }
 
     public reset() {
         this.setState({
@@ -46,12 +67,18 @@ export class ActivityBarService
         });
     }
 
-    public addBar(data: IActivityBarItem | IActivityBarItem[]) {
+    public addBar(
+        data: IActivityBarItem | IActivityBarItem[],
+        isActive = false
+    ) {
         let next = [...this.state.data!];
         if (Array.isArray(data)) {
             next = next?.concat(data);
         } else {
             next?.push(data);
+            if (isActive) {
+                this.setActive(data.id);
+            }
         }
         this.setState({
             data: next,
@@ -132,13 +159,15 @@ export class ActivityBarService
     }
 
     // ====== The belows for subscribe activity bar events ======
-    public onClick(callback: Function) {
+    public onClick(
+        callback: (selectedKey: string, item: IActivityBarItem) => void
+    ) {
         this.subscribe(ActivityBarEvent.OnClick, callback);
     }
 
-    public onSelect(
-        callback: (key: React.MouseEvent, item: IActivityBarItem) => void
+    public onChange(
+        callback: (prevSelectedKey?: string, nextSelectedKey?: string) => void
     ) {
-        this.subscribe(ActivityBarEvent.Selected, callback);
+        this.subscribe(ActivityBarEvent.OnChange, callback);
     }
 }

--- a/src/services/workbench/sidebarService.ts
+++ b/src/services/workbench/sidebarService.ts
@@ -8,7 +8,8 @@ import {
 } from 'mo/model/workbench/sidebar';
 
 export interface ISidebarService extends Component<ISidebar> {
-    push(data: ISidebarPane): void;
+    addPane(data: ISidebarPane, isActive?: boolean): void;
+    setActive(id?: string): void;
 }
 
 @singleton()
@@ -22,8 +23,22 @@ export class SidebarService
         this.state = container.resolve(SidebarModel);
     }
 
-    public push(data: ISidebarPane) {
-        const original = this.state.panes;
-        original?.push(data);
+    public addPane(data: ISidebarPane, isActive = false) {
+        const oldPanes = this.state.panes?.concat() || [];
+        oldPanes.push(data);
+        if (isActive) {
+            this.setState({
+                current: data.id,
+            });
+        }
+        this.setState({
+            panes: oldPanes,
+        });
+    }
+
+    public setActive(id?: string) {
+        this.setState({
+            current: id,
+        });
     }
 }

--- a/src/workbench/activityBar/activityBar.tsx
+++ b/src/workbench/activityBar/activityBar.tsx
@@ -23,14 +23,17 @@ export function ActivityBar(props: IActivityBar & IActivityBarController) {
         contextMenu = [],
         selected,
         onClick,
-        onSelect,
+        onChange,
         onContextMenuClick,
     } = props;
 
-    const onClickBar = (e: React.MouseEvent, item: IActivityBarItem) => {
-        if (onClick) onClick(e, item);
-        if (onSelect) {
-            onSelect(item.id || '', item);
+    const onClickBar = (key: string, item: IActivityBarItem) => {
+        if (onClick) onClick(key, item);
+        if (onChange) {
+            // only normal item trigger onChange event
+            if (item.type !== 'global') {
+                onChange(selected, key);
+            }
         }
     };
 

--- a/src/workbench/activityBar/activityBarItem.tsx
+++ b/src/workbench/activityBar/activityBarItem.tsx
@@ -63,7 +63,7 @@ export function ActivityBarItem(
 
     const onClickItem = function (event) {
         if (onClick) {
-            onClick(event, props);
+            onClick(props.id, props);
         }
         if (contextMenu.length > 0 && contextViewMenu) {
             contextViewMenu.show({

--- a/stories/extensions/test/index.tsx
+++ b/stories/extensions/test/index.tsx
@@ -6,35 +6,29 @@ import {
     MENU_VIEW_SIDEBAR,
     MENU_VIEW_STATUSBAR,
 } from 'mo/model/workbench/menuBar';
-import { IExtension, IActivityBarItem } from 'mo/model';
+import { IExtension } from 'mo/model';
 
 import TestPane from './testPane';
 
 export const ExtendTestPane: IExtension = {
     activate() {
+        const TEST_PANE_ID = 'ActivityBarTestPane';
         const testSidePane = {
-            id: 'testPane',
+            id: TEST_PANE_ID,
             title: 'TEST',
             render() {
                 return <TestPane />;
             },
         };
 
-        molecule.sidebar.push(testSidePane);
         const newItem = {
-            id: 'ActivityBarTestPane',
+            id: TEST_PANE_ID,
             iconName: 'codicon-beaker',
             name: '测试',
         };
-        molecule.activityBar.addBar(newItem);
 
-        molecule.activityBar.onSelect((e, item: IActivityBarItem) => {
-            if (item.id === newItem.id) {
-                molecule.sidebar.setState({
-                    current: testSidePane.id,
-                });
-            }
-        });
+        molecule.activityBar.addBar(newItem);
+        molecule.sidebar.addPane(testSidePane);
 
         molecule.settings.onChangeConfiguration(async (value) => {
             console.log('onChangeConfiguration:', value);


### PR DESCRIPTION
### 简介
- 重构了 activitybar 添加 panels 的方式，以及 sidebar 添加 pane 的方式，以及这两个 bar 之间的联动关系
- 支持通过点击当前 active 的 panel 来隐藏 sidebar

### 主要变更
- 考虑到 `onSelect` 和 `onClick` 事件的相似性，移除了 `onSelect` 事件，新增 `onChange` 事件
    -  `onChange` 事件仅 `normal` 可以触发
    -  `onChange` 事件可以获取到前后不同的 selectedKey 值
    - 同时，优化了 `onClick` 事件，新的 `onClick` 事件更偏向于之前的 `onSelect` 事件，但是全部的 bar item 都可以触发
- 移除了 `Explorer` `TestPane` 中通过 `setState` 的方式来新增 activityBar Panel，统一通过 addPanel 的方式来新增 Panel
- 移除了 `Explorer` `Search` `TestPane` 中通过 `setState` 或者 `push` 的方法来新增 sidebar Pane，sidebarService 新增 addPane 的方法，新增 Pane 统一走这个方法，并且移除了之前的 `push` 方法
- 移除了 `Explorer` `TestPane` `Search` 中的 `activityBarService.onSelect` 方法，放到 extension 里去了
- 优化了 `sidebar` 和 `activityBar` 的 `id` 不统一的问题，统一的 `id` 才能在 `onSelect` 中切换