### PR TITLE
fix(collapse): open editor not expand expected

### DIFF
--- a/src/components/collapse/index.tsx
+++ b/src/components/collapse/index.tsx
@@ -112,13 +112,20 @@ export function Collapse(props: ICollapseProps) {
             const dom = select<HTMLElement>(
                 `.${collapseItemClassName}[data-content='${panel.id}']`
             );
-            const contentDom = select<HTMLElement>(
-                `.${collapseContentClassName}[data-content='${panel.id}']`
-            );
-            if (dom && contentDom) {
+
+            // Only set content height for non-grow-zero panel
+            // 'Cause when you set height for grow-zero panel, you'll get wrong height next render time
+            if (panel.config?.grow !== 0) {
+                const contentDom = select<HTMLElement>(
+                    `.${collapseContentClassName}[data-content='${panel.id}']`
+                );
+                if (contentDom) {
+                    contentDom.style.height = `${height - HEADER_HEIGTH - 2}px`;
+                }
+            }
+            if (dom) {
                 dom.style.height = `${height}px`;
                 dom.style.top = `${top}px`;
-                contentDom.style.height = `${height - HEADER_HEIGTH - 2}px`;
             }
         });
     }, [filterData]);


### PR DESCRIPTION
### 简介
- 修复 Open Editor 窗口展开的高度没有按照期望的问题

### 主要变更
- 原因是因为 #194 这个 PR 里面通过直接给 `contentDom.style.height` 赋值来设置内容物高度，但是这么赋值之后，下次一个去计算高度的时候，`contentDom.getBoundingClientRect` 拿到的高度就一直是之前赋值的高度了。所以通过判断是否为 config.grow === 0 来区别对待不同的 panel，grow 为 0 的 panel 不进行内容高度的赋值