### PR TITLE
ci: exec check-types before commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "prettier": "prettier --ignore-unknown .",
         "pretty-quick": "pretty-quick",
         "release": "standard-version",
+        "precommit": "pretty-quick --staged && npm run check-types",
         "docs": "typedoc --entryPoints src/index.ts --out docs/api --name 'Molecule API'",
         "web": "webpack serve --env prod --config ./build/web.js"
     },
@@ -103,7 +104,7 @@
     "husky": {
         "hooks": {
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-            "pre-commit": "pretty-quick --staged"
+            "pre-commit": "npm run precommit"
         }
     },
     "config": {


### PR DESCRIPTION
# Description
- new script named `precommit`, which contains `check-types` and `pretty-quick` scripts
- exec `precommit` before `git commit`, 'Cause I always forget to check types