### PR TITLE
fix: improve activity context menu behavior

### DIFF
--- a/src/controller/activityBar.ts
+++ b/src/controller/activityBar.ts
@@ -95,14 +95,17 @@ export class ActivityBarController
             // activityBar contextMenu
             case CONTEXT_MENU_MENU: {
                 this.menuBarController.updateMenuBar!();
+                this.activityBarService.toggleContextMenuCheckStatus(
+                    contextMenuId
+                );
                 break;
             }
-            case CONTEXT_MENU_EXPLORER: {
-                this.activityBarService.toggleBar(contextMenuId);
-                break;
-            }
+            case CONTEXT_MENU_EXPLORER:
             case CONTEXT_MENU_SEARCH: {
                 this.activityBarService.toggleBar(contextMenuId);
+                this.activityBarService.toggleContextMenuCheckStatus(
+                    contextMenuId
+                );
                 break;
             }
             case CONTEXT_MENU_HIDE: {

--- a/src/model/workbench/activityBar.ts
+++ b/src/model/workbench/activityBar.ts
@@ -24,6 +24,7 @@ export interface IActivityBarItem {
     id: string;
     name?: ReactNode;
     title?: string;
+    hidden?: boolean;
     data?: any;
     iconName?: string;
     checked?: boolean;


### PR DESCRIPTION
### 简介
- 修复 activitybar 修改项目的 visibility 时，顺序会发生改变的问题
- 修复 contextMenu 修改项目的 visibility 后，contextMenu 的状态不会发生改变的问题
- 优化 contextMenu 弹出的交互效果

### 主要变更
- 由于之前 toggle 的时候，是用 remove add 的方式来实现的，重构掉之后依靠新增属性 hidden 来隐藏和显示
- 在 `toggleBar` 的时候，也需要一起 `toggleContextMenuCheckStatus`
- 优化 activitybar 的菜单弹出的方式，在观察 vscode 的弹出方式之后，目前逻辑如下：
    - 如果右键点击的位置是 item 的位置，则渲染菜单的位置在该 item 的右下方
    - 如果右键点击的位置是 item 的位置，则菜单项的首项新增一条当前 item 项目，并且与其他项目用分割线隔开
    - 如果右键点击的位置不是 item 的位置，则在点击位置渲染菜单