### PR TITLE
fix: the editor content incorrect when changing tabs

### DIFF
--- a/src/controller/editor.tsx
+++ b/src/controller/editor.tsx
@@ -181,7 +181,7 @@ export class EditorController extends Controller implements IEditorController {
         const tab = current?.tab;
         this.openFile(
             editorInstance,
-            tab?.name!,
+            tab?.id!,
             tab?.data?.value!,
             tab?.data?.language!
         );


### PR DESCRIPTION
### 简介
- 修复 editor 切换 tabs 的时候，editor 的内容变更不正确的问题


### 主要变更
- 主要问题在于在给每一个 tab 创建 model 的时候，会调用 `this.openFile` 而打开新文件和切换 tab 的时候该方法的 `path` 参数穿的值不一样，导致后续的一系列不正确的问题


### Related Issues
Closed #145 