### PR TITLE
fix: improve editor content change

### DIFF
--- a/src/components/monaco/index.tsx
+++ b/src/components/monaco/index.tsx
@@ -58,6 +58,7 @@ export class MonacoEditor extends PureComponent<IMonacoEditorProps> {
 
     componentDidUpdate(prevProps) {
         const { onChangeEditorProps } = this.props;
+        // TODO: Functions are compared by strict equality
         !isEqual(prevProps, this.props) &&
             onChangeEditorProps?.(prevProps, this.props);
     }


### PR DESCRIPTION
### 简介
- 修复在频繁切换 tab 的情况下，editor 的内容会显示不正确的问题


### 主要变更
- 主要问题在于 updateValue 的逻辑有问题
    - 原先的逻辑为：`tab.onClick -> onSelectTab -> setActive & updateCurrentValue`，`setActive -> update current -> tab.path -> editor.props -> onChangeEditorProps -> saveView & openFile -> updateValue & restoreView`;
    - 其中的问题在于 `updateCurrentValue` 和 `updateValue` 都是更新 value 的操作，重复更新了，并且 `updateCurrentValue` 和 `updateValue` 两者更新逻辑都有问题
    - 前者的问题在于更新值的时候用的 value 值是通过 model 拿到的，而此时由于还未进行 model 的修改，所以拿到的值是上一个 tab 的值（本次 PR 未修改此处）
    - 后者的问题在于当判断 model 是否存在，若存在，则执行 `instance.executeEdits` 修改当前 model 的值，然后后续又会通过 setModel 修改当前 model
 - 总结问题后，作出的修改如下：
     - 判断 model 是否存在，若存在，则修改 model 的值，然后后续通过 setModel 来修改 model


### 遗留问题
定位问题的过程中发现如下问题：
1. editor 中的注释偏少
2. 几个重要的函数不够语义化

后续将会对这一块重构


### Related Issues

Closed #145 