### PR TITLE
fix: improve editor content change

### DIFF
--- a/src/components/monaco/index.tsx
+++ b/src/components/monaco/index.tsx
@@ -58,6 +58,7 @@ export class MonacoEditor extends PureComponent<IMonacoEditorProps> {
 
     componentDidUpdate(prevProps) {
         const { onChangeEditorProps } = this.props;
+        // TODO: Functions are compared by strict equality
         !isEqual(prevProps, this.props) &&
             onChangeEditorProps?.(prevProps, this.props);
     }


### PR DESCRIPTION
### 简介
- 修复在切换 tab 的情况下，editor 内容显示不正确的问题
- 修复 #212 改完会出现的有关 editors undo 的问题


### 主要变更
- 优化函数名称并添加部分注释
- 在 select tab 的时候不需要执行 `setValue` 或者 `executeEdits`，只需要去执行 setModel 就可以做。因为 model 内部应该是储存了 undo-todo 的状态的，所以不需要额外的操作

### Related Issues
Closed #145 