### PR TITLE
fix: location render incorrect after editing

### DIFF
--- a/src/controller/editor.tsx
+++ b/src/controller/editor.tsx
@@ -225,7 +225,10 @@ export class EditorController extends Controller implements IEditorController {
             const { current } = this.editorService.getState();
             const tab = current?.tab;
             if (!tab) return;
-            const updatedTab = { ...tab, data: { value: newValue } };
+            const updatedTab = {
+                ...tab,
+                data: { ...tab.data, value: newValue },
+            };
             this.editorService.updateTab(updatedTab, groupId);
             this.emit(EditorEvent.OnUpdateTab, updatedTab);
             this.updateStatusBar(editorInstance);

--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -37,6 +37,7 @@ export const ExtendsFolderTree: IExtension = {
                 new TreeNodeModel({
                     id,
                     name: 'molecule',
+                    location: 'molecule',
                     fileType: FileTypes.RootFolder,
                 })
             );
@@ -74,18 +75,20 @@ export const ExtendsFolderTree: IExtension = {
 
         molecule.folderTree.onSelectFile(
             (file: ITreeNodeItemProps, isUpdate?: boolean) => {
-                const { fileType, isEditable } = file;
+                const { fileType, name, isEditable } = file;
                 const isFile = fileType === FileTypes.File;
                 molecule.folderTree.setActive(file?.id);
                 if (!isFile || isEditable) return;
+                const nameArr = name?.split('.') || [];
+                const extName = nameArr[nameArr.length - 1] || '';
                 const tabData = {
                     ...file,
                     id: `${file.id}`?.split('_')?.[0],
                     modified: false,
                     data: {
                         value: file.content,
-                        path: 'desktop/moslecule/editor1',
-                        language: 'sql',
+                        path: file.location,
+                        language: extName,
                     },
                 };
 
@@ -108,19 +111,22 @@ export const ExtendsFolderTree: IExtension = {
 
         molecule.folderTree.onUpdateFileName((file: ITreeNodeItemProps) => {
             const { folderTree } = molecule.folderTree.getState();
-            const { id, name, fileType } = file as any;
+            const { id, name, fileType, location } = file as any;
             const cloneData: ITreeNodeItemProps[] = folderTree?.data || [];
             const {
                 tree,
                 index,
             } = molecule.folderTree.getCurrentRootFolderInfo(id);
             if (name) {
+                const newLoc = location.split('/');
+                newLoc[newLoc.length - 1] = name;
                 tree.update(id, {
                     ...file,
                     icon: molecule.folderTree.getFileIconByExtensionName(
                         name,
                         fileType
                     ),
+                    location: newLoc.join('/'),
                     isEditable: false,
                 });
             } else {

--- a/src/services/workbench/explorer/folderTreeService.ts
+++ b/src/services/workbench/explorer/folderTreeService.ts
@@ -81,8 +81,12 @@ export class FolderTreeService
             // TODO: this function has incorrect return type
             const currentIndex: any = tree.getIndex(id);
             if (currentIndex?.node?.fileType === FileTypes.File) {
+                const locations = currentIndex.node.location.split('/');
+                locations[locations.length - 1] = data.name;
+                data.location = locations.join('/');
                 tree.prepend(data, currentIndex.parent);
             } else {
+                data.location = `${currentIndex.node.location}/${data.name}`;
                 tree.append(data, id);
             }
             cloneData[index] = tree.obj;


### PR DESCRIPTION
### 简介
- 修复编辑之后，包括 language location 等属性丢失的问题
- 修复打开新文件没有 location 的问题
- 修复打开新文件 language 只有 sql 的问题


### 主要变更
- 优化 editor 的 onModelChange 事件
- 优化 onSelect 打开新文件的事件
- 新增文件的时候会添加 location，修改文件名称同样会修改 location 字段