### PR TITLE
fix: improve workbench height & box-sizing

### DIFF
--- a/src/components/collapse/style.scss
+++ b/src/components/collapse/style.scss
@@ -40,11 +40,12 @@ $collapse__extra: #{$collapse}__extra;
     &__header {
         align-items: center;
         border: 1px solid transparent;
+        box-sizing: border-box;
         cursor: pointer;
         display: flex;
         font-size: 11px;
         font-weight: bold;
-        height: 22px;
+        height: 25px;
         outline: none;
         padding: 1px 2px;
         user-select: none;

--- a/src/workbench/activityBar/style.scss
+++ b/src/workbench/activityBar/style.scss
@@ -2,7 +2,6 @@
 
 #{$activityBar} {
     flex: 1;
-    padding-bottom: 20px;
     width: 48px;
 
     &__container {

--- a/src/workbench/sidebar/style.scss
+++ b/src/workbench/sidebar/style.scss
@@ -6,6 +6,10 @@
     position: relative;
     width: 100%;
 
+    &-explorer {
+        height: 100%;
+    }
+
     h2 {
         cursor: default;
         font-size: 11px;
@@ -44,7 +48,7 @@
 
     &__content {
         bottom: 0;
-        height: calc(100vh - 57px);
+        height: calc(100% - 35px);
         left: 0;
         position: relative;
         right: 0;

--- a/src/workbench/style.scss
+++ b/src/workbench/style.scss
@@ -2,6 +2,7 @@
 
 #{$workbench} {
     bottom: 0;
+    height: calc(100% - 22px);
     left: 0;
     position: absolute;
     right: 0;


### PR DESCRIPTION
### 简介
- 修复 `workbench` 的高度问题，该问题会导致后续 collapse 计算高度出现误差。
- 修复引入 `antd` 样式后，由于 `ant-layout` 会修改子节点的 `box-sizing` 导致出现样式误差

### 主要变更
- `workbench` 设置高度，防止后续出现误差
- 优化设置了 `border-box` 的以后的节点的样式
- 由于 `workbench` 的高度设置了以后会比设置之前少一些，所以 global activity bar 的按钮的 `padding` 可以不需要设置了