### PR TITLE
fix: improve unreasonable design

### DIFF
--- a/src/components/menu/menuItem.tsx
+++ b/src/components/menu/menuItem.tsx
@@ -31,6 +31,8 @@ export interface IMenuItemProps extends HTMLElementProps {
     render?: (data: IMenuItemProps) => ReactNode;
     onClick?: (e: React.MouseEvent, item?: IMenuItemProps) => void;
     sortIndex?: number;
+
+    [key: string]: any;
 }
 
 export function MenuItem(props: React.PropsWithChildren<IMenuItemProps>) {

--- a/src/controller/editor.tsx
+++ b/src/controller/editor.tsx
@@ -101,6 +101,9 @@ export class EditorController extends Controller implements IEditorController {
                 this.onCloseToLeft(tabItem!, groupId);
                 break;
             }
+            default: {
+                this.emit(EditorEvent.onActionsClick, menuId, current);
+            }
         }
     };
 

--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -1,48 +1,10 @@
 import molecule from 'mo';
 import { IExtension } from 'mo/model/extension';
 import { ITreeNodeItemProps } from 'mo/components/tree';
-import { FileTypes, TreeNodeModel } from 'mo/model';
-import { randomId } from 'mo/common/utils';
+import { FileTypes } from 'mo/model';
 
 export const ExtendsFolderTree: IExtension = {
     activate() {
-        molecule.folderTree.onNewFile((id: number) => {
-            // work through addNode function
-            molecule.folderTree.addNode(
-                id,
-                new TreeNodeModel({
-                    id: randomId(),
-                    name: '',
-                    fileType: FileTypes.File,
-                    isEditable: true,
-                })
-            );
-        });
-
-        molecule.folderTree.onNewFolder((id: number) => {
-            // work through addNode function
-            molecule.folderTree.addNode(
-                id,
-                new TreeNodeModel({
-                    id: randomId(),
-                    name: '',
-                    fileType: FileTypes.Folder,
-                    isEditable: true,
-                })
-            );
-        });
-
-        molecule.folderTree.onNewRootFolder((id: number) => {
-            molecule.folderTree.addRootFolder?.(
-                new TreeNodeModel({
-                    id,
-                    name: 'molecule',
-                    location: 'molecule',
-                    fileType: FileTypes.RootFolder,
-                })
-            );
-        });
-
         molecule.folderTree.onDelete((id: number) => {
             const { folderTree } = molecule.folderTree.getState();
             const cloneData: ITreeNodeItemProps[] = folderTree?.data || [];

--- a/src/model/workbench/editor.ts
+++ b/src/model/workbench/editor.ts
@@ -14,6 +14,7 @@ export enum EditorEvent {
     OpenTab = 'editor.openTab',
     OnSelectTab = 'editor.selectTab',
     OnUpdateTab = 'editor.updateTab',
+    onActionsClick = 'editor.actionsClick',
     OnSplitEditorRight = 'editor.splitEditorRight',
 }
 interface BuiltInEditorTabDataType {

--- a/stories/extensions/test/index.tsx
+++ b/stories/extensions/test/index.tsx
@@ -5,11 +5,12 @@ import {
     MENU_VIEW_MENUBAR,
     MENU_VIEW_STATUSBAR,
 } from 'mo/model/workbench/menuBar';
-import { IExtension } from 'mo/model';
+import { FileTypes, IExtension, TreeNodeModel } from 'mo/model';
 
 import TestPane from './testPane';
 import { Entry } from './entry';
 import { Position } from 'mo/model/workbench/layout';
+import { randomId } from 'mo/common/utils';
 
 export const ExtendTestPane: IExtension = {
     activate() {
@@ -82,6 +83,43 @@ export const ExtendTestPane: IExtension = {
                     icon: hidden ? '' : 'check',
                 });
             }
+        });
+
+        molecule.folderTree.onNewFile((id: number) => {
+            // work through addNode function
+            molecule.folderTree.addNode(
+                id,
+                new TreeNodeModel({
+                    id: randomId(),
+                    name: '',
+                    fileType: FileTypes.File,
+                    isEditable: true,
+                })
+            );
+        });
+
+        molecule.folderTree.onNewFolder((id: number) => {
+            // work through addNode function
+            molecule.folderTree.addNode(
+                id,
+                new TreeNodeModel({
+                    id: randomId(),
+                    name: '',
+                    fileType: FileTypes.Folder,
+                    isEditable: true,
+                })
+            );
+        });
+
+        molecule.folderTree.onNewRootFolder((id: number) => {
+            molecule.folderTree.addRootFolder?.(
+                new TreeNodeModel({
+                    id,
+                    name: 'molecule',
+                    location: 'molecule',
+                    fileType: FileTypes.RootFolder,
+                })
+            );
         });
     },
 };


### PR DESCRIPTION
### 简介
- 修复在开发 ScheduleX 的时候遇到的一些不合理的地方

### 主要变更
- menu 支持 `[key:string]: any` 拓展属性
- editor group 的 actions 支持通过 `updateGroupActions` 方法扩展新的属性
- 支持通过 `onActionsClick` 事件监听到 editor group 的 actions 的点击事件
- folderTree 的 newFile 由于在 ScheduleX 中需要重写交互，所以考虑把新建文件的操作从内置的 extensions 中移除了。并且由于 `newFile; newFolder; newRootFolder;` 三者具有相似性，所以把这三者全部从内置的 extensions 中移除，让用户自行实现