### PR TITLE
fix: improve the timing when to check empty of panels

### DIFF
--- a/src/components/collapse/index.tsx
+++ b/src/components/collapse/index.tsx
@@ -93,6 +93,7 @@ export function Collapse(props: ICollapseProps) {
     }, []);
 
     React.useLayoutEffect(() => {
+        // It's necessary to check panel's empty before calculate every panel
         filterData.forEach((panel) => {
             const isActive = activePanelKeys.includes(panel.id);
             let isEmpty = true;
@@ -103,6 +104,9 @@ export function Collapse(props: ICollapseProps) {
                 isEmpty = !contentDom?.hasChildNodes();
             }
             panel._isEmpty = isEmpty;
+        });
+
+        filterData.forEach((panel) => {
             const [height, top] = calcPosition(
                 activePanelKeys,
                 panel,


### PR DESCRIPTION
### 简介
- 修复在先打开文件树的情况下，无法打开 outline 的问题

### 主要变更
- 主要原因是因为去判断 panel 是否 empty 的时机不对，`calcPosition` 函数的执行依赖于所有 panel 的 isEmpty 属性，所以在第一个 panel 去执行该函数前就应该把所有的 panels 的 isEmpty 状态更新掉，而不是之前在每一个 panel 计算之前再去更新状态