### PR TITLE
fix: duplicate command palette in editor context menu

### DIFF
--- a/src/model/keybinding.ts
+++ b/src/model/keybinding.ts
@@ -64,6 +64,6 @@ export interface ISimpleKeybinding {
 
 export const ACTION_QUICK_ACCESS_SETTINGS =
     'workbench.action.quickAccessSettings';
-export const ACTION_QUICK_COMMAND = 'workbench.action.quickCommand';
+export const ACTION_QUICK_COMMAND = 'editor.action.quickCommand';
 export const ACTION_SELECT_THEME = 'workbench.action.selectTheme';
 export const ACTION_SELECT_LOCALE = 'workbench.action.selectLocale';

--- a/src/monaco/quickAccessViewAction.ts
+++ b/src/monaco/quickAccessViewAction.ts
@@ -185,11 +185,6 @@ export class CommandQuickAccessViewAction extends Action2 {
                 primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_P,
                 secondary: [KeyCode.F1],
             },
-            menu: {
-                id: MenuId.EditorContext,
-                group: 'z_commands',
-                order: 1,
-            },
         });
     }
 


### PR DESCRIPTION
### 简介
- 修复 editor 的右键菜单存在重复的命令面板

### 主要变更
- editor 的右键菜单自带了一个 Command Palette，只是没有快捷键绑定
- So，添加快捷键绑定的时候不需要在 menu 上添加了，并且优化了 action 的 id，和 monaco 内置的保持一致，否则找不到 id 就显示不了快捷键了

### Related Issues
closed #241 