### PR TITLE
fix: update foldertree new folder

### DIFF
--- a/src/components/tree/index.tsx
+++ b/src/components/tree/index.tsx
@@ -168,6 +168,31 @@ const TreeView = ({
         onRightClick?.(info);
     };
 
+    React.useLayoutEffect(() => {
+        const cache: { path: string; data: ITreeNodeItemProps }[] = [];
+        data.forEach((item) => {
+            cache.push({ path: `${item.id}`, data: item });
+        });
+
+        while (cache.length) {
+            const { path, data } = cache.pop()!;
+            const editableChild = data.children?.find(
+                (child) => child.isEditable
+            );
+            if (editableChild) {
+                treeRef.current?.setExpandedKeys(path.split('-'));
+                break;
+            } else {
+                const children =
+                    data.children?.map((child) => ({
+                        path: `${path}-${child.id}`,
+                        data: child,
+                    })) || [];
+                cache.push(...children);
+            }
+        }
+    }, [data]);
+
     return (
         <div className={classNames(prefixClaName('tree'), className)}>
             <div className={prefixClaName('tree', 'sidebar')}>

--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -48,6 +48,7 @@ export const ExtendsFolderTree: IExtension = {
                     id: `${file.id}`?.split('_')?.[0],
                     modified: false,
                     data: {
+                        ...(file.data || {}),
                         value: file.content,
                         path: file.location,
                         language: extName,
@@ -92,12 +93,29 @@ export const ExtendsFolderTree: IExtension = {
                     isEditable: false,
                 });
             } else {
-                tree.remove(id);
+                // TODO: improve tree helper types
+                const node = (tree.get(id) as unknown) as ITreeNodeItemProps;
+                if (node.name) {
+                    tree.update(id, {
+                        isEditable: false,
+                    });
+                } else {
+                    tree.remove(id);
+                }
             }
+
             if (index > -1) cloneData[index] = tree.obj;
             molecule.folderTree.setState({
                 folderTree: { ...folderTree, data: cloneData },
             });
+
+            const isOpened = molecule.editor.isOpened(id.toString());
+            if (isOpened) {
+                molecule.editor.updateTab({
+                    id: id.toString(),
+                    name,
+                });
+            }
             if (file?.fileType === FileTypes.File && file.name) {
                 // emit onSelectFile
             }

--- a/src/model/workbench/explorer/folderTree.tsx
+++ b/src/model/workbench/explorer/folderTree.tsx
@@ -102,11 +102,14 @@ export class TreeNodeModel implements ITreeNodeItemProps {
     id?: number;
     name?: string;
     location?: string;
+    isLeaf?: boolean;
     fileType?: FileType;
     children?: ITreeNodeItemProps[];
     icon?: string | React.ReactNode;
     isEditable?: boolean;
     content?: string;
+
+    data?: any;
 
     constructor(props: ITreeNodeItemProps = {}) {
         const {
@@ -118,6 +121,8 @@ export class TreeNodeModel implements ITreeNodeItemProps {
             icon = '',
             isEditable = false,
             content = '',
+            isLeaf = true,
+            data,
         } = props;
         this.fileType = fileType;
         this.isEditable = isEditable;
@@ -127,6 +132,8 @@ export class TreeNodeModel implements ITreeNodeItemProps {
         this.children = children;
         this.icon = icon;
         this.content = content;
+        this.data = data;
+        this.isLeaf = isLeaf;
     }
 }
 

--- a/src/services/workbench/explorer/folderTreeService.ts
+++ b/src/services/workbench/explorer/folderTreeService.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { singleton, container } from 'tsyringe';
+import cloneDeep from 'lodash/cloneDeep';
 import { Component } from 'mo/react/component';
 import {
     FileTypes,
@@ -91,7 +92,10 @@ export class FolderTreeService
             }
             cloneData[index] = tree.obj;
             this.setState({
-                folderTree: { ...this.state.folderTree, data: cloneData },
+                folderTree: {
+                    ...this.state.folderTree,
+                    data: cloneDeep(cloneData),
+                },
             });
         } else {
             console.warn('Please check id again, there is not folder tree');

--- a/stories/extensions/test/index.tsx
+++ b/stories/extensions/test/index.tsx
@@ -106,6 +106,7 @@ export const ExtendTestPane: IExtension = {
                     id: randomId(),
                     name: '',
                     fileType: FileTypes.Folder,
+                    isLeaf: false,
                     isEditable: true,
                 })
             );


### PR DESCRIPTION
### 简介
- 修复 folderTree 修改名称的时候，如果没有名称会直接删除节点的问题
- 修复 folderTree 在收起状态的文件夹下新增节点的时候，该文件夹不会展开的问题
- 修复 folderTree 修改名称之后，tab 没有同步更新的问题

### 主要变更
- 在 rename 触发事件中增加判断逻辑，如果没有不存在 name ，不可以直接删除节点，需要先去拿到当前节点在 tree 中的状态。如果状态存在且有 name 则表示是编辑，那就取消编辑状态就可以了，否则再删除节点
- 在 rename 触发事件的结尾，判断当前修改的节点是否存在于 tab 中，如果是则去修改 tab 内容
- 优化 updateTab 函数，由于同一个文件可能会在多个 group 中打开，所以需要去遍历全部的 group 做修改。同时，修改内容不应该理论上只修改 `group.data`，但是实际上应该修改 `group.tab` `current.tab` `group.data` 至少三处，来确保数据的一致性
- addNode 赋值 state 的时候，通过深拷贝可以触发 data 的引用地址不同，从而触发 view 的 `useLayoutEffect`，然后借助一个 stack 来层次遍历 data，并记录遍历的 path，对 path 上的每一个文件夹都做 expand 操作

### Related Issues

Closed #244 