### PR TITLE
fix: icon support spin

### DIFF
--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -15,7 +15,8 @@ export function Icon(props: React.PropsWithChildren<IIconProps>) {
             className={classNames(
                 className,
                 'codicon',
-                prefixClaName(type, 'codicon')
+                type.includes('~spin') && 'codicon-spin',
+                prefixClaName(type.split('~spin')[0], 'codicon')
             )}
             {...restProps}
         >

--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -48,10 +48,10 @@ export const ExtendsFolderTree: IExtension = {
                     id: `${file.id}`?.split('_')?.[0],
                     modified: false,
                     data: {
-                        ...(file.data || {}),
                         value: file.content,
                         path: file.location,
                         language: extName,
+                        ...(file.data || {}),
                     },
                 };
 

--- a/src/style/animation.scss
+++ b/src/style/animation.scss
@@ -11,3 +11,17 @@
 .fade-in {
     animation: fadeIn 0.083s linear;
 }
+
+@keyframes fa-spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(359deg);
+    }
+}
+
+.codicon-spin {
+    animation: fa-spin 2s infinite linear;
+}

--- a/src/workbench/editor/style.scss
+++ b/src/workbench/editor/style.scss
@@ -49,6 +49,7 @@
             &--disabled {
                 cursor: default;
                 opacity: 0.4;
+                pointer-events: none;
             }
         }
     }


### PR DESCRIPTION
### 简介
- 修复 icon 无法旋转的问题
- 修复 editor actions disabled 后还能够点击的问题
- 修复 `file.data` 无法覆盖的问题

### 主要变更
- vscode 的 icon 是支持在结尾通过添加 `~spin` 来实现任意 icon 旋转的功能，但是目前看来 @vscode/codicon 这个包里没有实现这个功能，不知道是什么情况，暂时先自己实现了