### PR TITLE
feat: gulp task support to watch file changed

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -96,3 +96,31 @@ gulp.task(
         'build:i18n'
     )
 );
+
+gulp.task(
+    'watch',
+    gulp.series(
+        'clean',
+        'build:esm',
+        'build:sass',
+        'build:extensions',
+        'build:i18n',
+        function watchFiles() {
+            gulp.watch('../src/**/*.scss', gulp.series('build:sass'));
+            gulp.watch(
+                ['../src/**/*.ts', '../src/**/*.tsx'],
+                gulp.series('build:esm')
+            );
+            gulp.watch(
+                [
+                    '../src/extension/**/*.svg',
+                    '../src/extension/**/*.json',
+                    '../src/extension/**/*.png',
+                    '../src/extension/**/*.md',
+                ],
+                gulp.series('build:extensions')
+            );
+            gulp.watch('../src/i18n/**/*.json', gulp.series('build:i18n'));
+        }
+    )
+);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "build-umd": "rimraf umd && webpack --config ./build/webpack.umd.js",
         "check-types": "tsc",
         "build": "gulp --gulpfile ./build/gulpfile.js",
+        "watch": "gulp --gulpfile ./build/gulpfile.js watch",
         "eslint": "eslint ./src/**/*.ts ./src/**/*.tsx",
         "stylelint": "stylelint **/*.{css,scss,sass}",
         "prettier": "prettier --ignore-unknown .",


### PR DESCRIPTION
### 简介
- 苦没有 watch 久已，由于 scheduleX 的开发需要用到 molecule，而没有 watch 导致需要手动跑一次 build

### 遗留问题
- 目前 `*.tsx *.ts` 的文件还无法做到只更新一个文件，需要跑 esm 这个任务，会去 build 全部的 esm 出来，没想到什么解决办法