### PR TITLE
fix: fix keybinding invalidation when dispose an editor

### DIFF
--- a/src/model/workbench/panel.tsx
+++ b/src/model/workbench/panel.tsx
@@ -43,6 +43,8 @@ export function builtInOutputPanel() {
         editorInstance: IStandaloneCodeEditor,
         item: IOutput
     ) {
+        // Please notice the problem about memory out
+        // 'Cause we didn't dispose the older instance
         item.outputEditorInstance = editorInstance;
     }
 

--- a/src/workbench/panel/output.tsx
+++ b/src/workbench/panel/output.tsx
@@ -6,12 +6,7 @@ import { MonacoEditor } from 'mo/components/monaco';
 const defaultClassName = prefixClaName('output');
 
 function Output(props: IOutput) {
-    const { id, data = '', onUpdateEditorIns, outputEditorInstance } = props;
-    const editorDidMount = React.useRef(false);
-
-    if (!editorDidMount.current && outputEditorInstance) {
-        outputEditorInstance.dispose();
-    }
+    const { id, data = '', onUpdateEditorIns } = props;
 
     return (
         <div className={defaultClassName}>
@@ -29,7 +24,6 @@ function Output(props: IOutput) {
                 }}
                 editorInstanceRef={(editorInstance) => {
                     onUpdateEditorIns?.(editorInstance);
-                    editorDidMount.current = true;
                 }}
             />
         </div>


### PR DESCRIPTION
### 简介
- 修复由于 #252 中 `dispose` 所导致的快捷键绑定失效的问题

### 主要变更
- 目前无法得知为什么 `dispose` 会导致快捷键失效的原因，所以暂时先不 `dispose`，并且新增有关内存溢出的风险的注释，为后续假如由于没有 `dispose` 导致内存占用率过高或者内存溢出的问题做好定位

### 遗留问题
- `dispose` 为何会导致快捷键失效