### PR TITLE
fix: improve close group in editor

### DIFF
--- a/src/workbench/editor/group.tsx
+++ b/src/workbench/editor/group.tsx
@@ -94,6 +94,7 @@ export function EditorGroup(props: IEditorGroupProps & IEditorController) {
                         )
                     ) : (
                         <MonacoEditor
+                            key={tab.id}
                             options={{
                                 value: tab.data?.value,
                                 language: tab.data?.language,


### PR DESCRIPTION
### 简介
- 修复 editor 标签组关闭时，会导致 editor 消失的问题
- 优化 editor 实例销毁 model 实例的逻辑
- 修复当 editor 标签组位于第一个的时候，关闭标签组不会自动切换到下一个标签组的问题

### 主要变更
- 导致 editor 消失的问题，经过定位发现是 key 的问题。当关闭标签组内最后一个标签会导致标签组关闭，会触发 `MonacoEditor` 组件的重渲染，但是由于没有设置 key 的问题，导致重渲染有问题
- 之前销毁 model 的逻辑有问题，没有去判断要销毁的 model 所对应的 tab 在其他标签组存在打开的情况

### Related Issues

Closed #266 Closed #265 