### PR TITLE
fix: maximized icon displayed incorrect

### DIFF
--- a/src/i18n/source/en.ts
+++ b/src/i18n/source/en.ts
@@ -51,6 +51,7 @@ export default {
         'panel.output.title': 'output',
         'panel.toolbox.closePanel': 'Close Panel',
         'panel.toolbox.maximize': 'Maximize Panel Size',
+        'panel.toolbox.restoreSize': 'Restore Panel Size',
         'panel.problems.title': 'Problems',
         'panel.problems.empty':
             'No problems have been detected in the workspace.',

--- a/src/i18n/source/zh-CN.json
+++ b/src/i18n/source/zh-CN.json
@@ -51,6 +51,7 @@
         "panel.problems.empty": "未在工作区检测到问题",
         "panel.toolbox.closePanel": "关闭面板",
         "panel.toolbox.maximize": "最大化面板",
+        "panel.toolbox.restoreSize": "恢复面板大小",
         "notification.title": "通知",
         "notification.title.no": "没有新通知",
         "editor.closeToRight": "关闭右边",

--- a/src/services/workbench/panelService.ts
+++ b/src/services/workbench/panelService.ts
@@ -67,6 +67,8 @@ export class PanelService extends Component<IPanel> implements IPanelService {
         const resizeBtn = toolbox[resizeBtnIndex];
         if (resizeBtn) {
             if (panelMaximized) {
+                toolbox[resizeBtnIndex] = builtInPanelToolboxResize();
+            } else {
                 toolbox[resizeBtnIndex] = Object.assign({}, resizeBtn, {
                     title: localize(
                         PANEL_TOOLBOX_RESTORE_SIZE,
@@ -74,8 +76,6 @@ export class PanelService extends Component<IPanel> implements IPanelService {
                     ),
                     iconName: 'codicon-chevron-down',
                 });
-            } else {
-                toolbox[resizeBtnIndex] = builtInPanelToolboxResize();
             }
             this.layoutService.togglePanelMaximized();
         }


### PR DESCRIPTION
### 简介
- 修复 panel 面板最大化的图标和行为不匹配的问题


### 主要变更
- 最大化面板的逻辑中 `panelMaximized` 是变更之前的值，所以旧的逻辑判断是相反的
### Related Issues

Closed #279 