### PR TITLE
refactor: improve search controller & service

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -10,10 +10,13 @@ import {
     replaceContainerClassName,
     searchTargetContainerClassName,
 } from './base';
+
+export type SearchValues = (string | undefined)[];
+
 export interface ISearchProps extends React.ComponentProps<any> {
     style?: React.CSSProperties;
     className?: string;
-    values?: (string | undefined)[];
+    values?: SearchValues;
     placeholders?: string[];
     addons?: (IActionBarItemProps[] | undefined)[];
     validationInfo?: string | { type: keyof typeof InfoTypeEnum; text: string };
@@ -26,11 +29,11 @@ export interface ISearchProps extends React.ComponentProps<any> {
      *
      * second value is from replace input
      */
-    onChange?: (value?: (string | undefined)[]) => void;
+    onChange?: (value?: SearchValues) => void;
     /**
      * onSearch always be triggered behind onChange or onClick
      */
-    onSearch?: (value?: (string | undefined)[]) => void;
+    onSearch?: (value?: SearchValues) => void;
 }
 
 export function Search(props: ISearchProps) {
@@ -46,10 +49,12 @@ export function Search(props: ISearchProps) {
         onChange,
         onSearch,
     } = props;
+
     const [
         searchPlaceholder = 'Search',
         replacePlaceholder = 'Replace',
     ] = placeholders;
+
     const [searchAddons, replaceAddons] = addons;
     const [searchVal, replaceVal] = values;
 

--- a/src/components/search/input.tsx
+++ b/src/components/search/input.tsx
@@ -103,7 +103,9 @@ function Input(props: IBaseInputProps) {
                 spellCheck={false}
                 autoCorrect="off"
                 autoCapitalize="off"
-                className={classNames(getInfoClassName(info?.type || ''))}
+                className={classNames(
+                    info?.text && getInfoClassName(info?.type || '')
+                )}
                 value={value || ''}
                 placeholder={placeholder}
                 title={placeholder}
@@ -112,7 +114,7 @@ function Input(props: IBaseInputProps) {
                 onBlur={handleInputBlur}
                 onChange={handleInputChange}
             />
-            {info && focusStatus && (
+            {info?.text && focusStatus && (
                 <div
                     className={classNames(
                         validationBaseInputClassName,

--- a/src/components/search/style.scss
+++ b/src/components/search/style.scss
@@ -1,4 +1,5 @@
 @import 'mo/style/common';
+$icon-size: 20px;
 
 #{$search} {
     display: grid;
@@ -58,29 +59,27 @@
     }
 
     &__toolbar {
-        height: 100%;
         position: absolute;
         right: 0;
-        top: 0;
+        top: 2px;
 
         #{$actionBar} {
             &__label {
-                height: 19px;
-                margin: 2px 1px;
+                height: $icon-size;
                 min-width: auto;
                 opacity: 0.7;
                 padding: 0;
                 transition: opacity 0.3s;
-                width: 22px;
-
-                &:hover {
-                    opacity: 1;
-                }
+                width: $icon-size;
             }
 
-            &__item--checked {
-                background: var(--inputOption-activeBackground);
-                opacity: 1;
+            &__item {
+                color: var(--activityBar-foreground);
+
+                &--checked {
+                    background: var(--inputOption-activeBackground);
+                    opacity: 1;
+                }
             }
         }
     }
@@ -99,7 +98,7 @@
         position: absolute;
         z-index: 1;
 
-        &:not(input) {
+        &:not(textarea) {
             margin-top: -1px;
             width: calc(100% - 12px);
         }
@@ -113,7 +112,7 @@
             border-color: var(--inputValidation-infoBorder);
         }
 
-        &:not(input) {
+        &:not(textarea) {
             background: var(--inputValidation-infoBackground);
         }
     }
@@ -126,7 +125,7 @@
             border-color: var(--inputValidation-warningBorder);
         }
 
-        &:not(input) {
+        &:not(textarea) {
             background: var(--inputValidation-warningBackground);
         }
     }
@@ -139,7 +138,7 @@
             border-color: var(--inputValidation-errorBorder);
         }
 
-        &:not(input) {
+        &:not(textarea) {
             background: var(--inputValidation-errorBackground);
         }
     }

--- a/src/extensions/theme-defaults/themes/dark_defaults.json
+++ b/src/extensions/theme-defaults/themes/dark_defaults.json
@@ -15,6 +15,7 @@
         "list.inactiveSelectionBackground": "#37373D",
         "list.focusOutline": "#007FD4",
         "activityBarBadge.background": "#007ACC",
+        "activityBar.foreground": "#fff",
         "activityBar.inactiveForeground": "#ffffff66",
         "sidebarTitle.foreground": "#BBBBBB",
         "sideBarSectionHeader.border": "#ccc3",

--- a/src/extensions/theme-defaults/themes/light_defaults.json
+++ b/src/extensions/theme-defaults/themes/light_defaults.json
@@ -12,6 +12,7 @@
         "editorSuggestWidget.background": "#F3F3F3",
         "activityBarBadge.background": "#007ACC",
         "activityBar.inactiveForeground": "#ffffff66",
+        "activityBar.foreground": "#fff",
         "sidebarTitle.foreground": "#6F6F6F",
         "sideBarSectionHeader.border": "#61616130",
         "list.hoverBackground": "#E8E8E8",

--- a/src/model/workbench/search.tsx
+++ b/src/model/workbench/search.tsx
@@ -1,14 +1,24 @@
+import { ITreeNodeItemProps } from 'mo/components';
 import { IActionBarItemProps } from 'mo/components/actionBar';
 import { InfoTypeEnum } from 'mo/components/search/input';
 import { localize } from 'mo/i18n/localize';
+
+export enum SearchEvent {
+    onChange = 'search.onChange',
+    onSearch = 'search.onSearch',
+    onReplaceAll = 'search.onReplaceAll',
+    onResultClick = 'search.onResultClick',
+}
+
 export interface ISearchProps {
     headerToolBar?: IActionBarItemProps[];
     searchAddons?: IActionBarItemProps[];
     replaceAddons?: IActionBarItemProps[];
+    result: ITreeNodeItemProps[];
     value?: string;
     replaceValue?: string;
     replaceMode?: boolean;
-    validationInfo?: string | { type: keyof typeof InfoTypeEnum; text: string };
+    validationInfo?: { type: keyof typeof InfoTypeEnum; text: string };
     isRegex?: boolean;
     isCaseSensitive?: boolean;
     isWholeWords?: boolean;
@@ -110,6 +120,7 @@ export class SearchModel implements ISearchProps {
     public headerToolBar: IActionBarItemProps[];
     public searchAddons: IActionBarItemProps[];
     public replaceAddons: IActionBarItemProps[];
+    public result: ITreeNodeItemProps[] = [];
     public value: string = '';
     public replaceValue: string = '';
     public replaceMode: boolean = false;
@@ -117,12 +128,16 @@ export class SearchModel implements ISearchProps {
     public isCaseSensitive: boolean = false;
     public isWholeWords: boolean = false;
     public preserveCase: boolean = false;
-    public validationInfo: string = '';
+    public validationInfo: { type: keyof typeof InfoTypeEnum; text: string } = {
+        type: 'info',
+        text: '',
+    };
 
     constructor(
         headerToolBar: IActionBarItemProps[] = [],
         searchAddons: IActionBarItemProps[] = [],
         replaceAddons: IActionBarItemProps[] = [],
+        result = [],
         value = '',
         replaceValue = '',
         replaceMode = false,
@@ -130,7 +145,10 @@ export class SearchModel implements ISearchProps {
         isWholeWords = false,
         isRegex = false,
         preserveCase = false,
-        validationInfo = ''
+        validationInfo: { type: keyof typeof InfoTypeEnum; text: string } = {
+            type: 'info',
+            text: '',
+        }
     ) {
         this.headerToolBar = headerToolBar;
         this.searchAddons = searchAddons;
@@ -142,6 +160,7 @@ export class SearchModel implements ISearchProps {
         this.isWholeWords = isWholeWords;
         this.isRegex = isRegex;
         this.preserveCase = preserveCase;
+        this.result = result;
         this.validationInfo = validationInfo;
     }
 }

--- a/src/workbench/sidebar/search/searchTree.tsx
+++ b/src/workbench/sidebar/search/searchTree.tsx
@@ -1,99 +1,21 @@
-import 'reflect-metadata';
-import * as React from 'react';
-import { memo } from 'react';
+import React, { memo } from 'react';
 import Tree, { ITreeProps } from 'mo/components/tree';
-import {
-    deleteSearchValueClassName,
-    emptyTextValueClassName,
-    matchSearchValueClassName,
-    replaceSearchValueClassName,
-    treeContentClassName,
-} from './base';
-import { FolderTreeController } from 'mo/controller/explorer/folderTree';
-import { container } from 'tsyringe';
-import { classNames } from 'mo/common/className';
-export interface SearchTreeProps extends ITreeProps {
-    value?: string;
-    emptyText?: string;
-    replaceValue?: string;
-    isCaseSensitive?: boolean;
-    isWholeWords?: boolean;
-    isRegex?: boolean;
-    /**
-     * Returns the position of the first occurrence of a substring.
-     */
-    getSearchIndex: (text: string, queryVal?: string) => number;
-}
+import { treeContentClassName } from './base';
 
-const folderTreeController = container.resolve(FolderTreeController);
-
-const Empty = ({ title }: { title?: string }) => {
-    return (
-        <div className={emptyTextValueClassName}>
-            {title || '未找到结果，请重新修改您的搜索条件'}
-        </div>
-    );
-};
+export interface SearchTreeProps extends ITreeProps {}
 
 const SearchTree = (props: SearchTreeProps) => {
-    const {
-        data = [],
-        value = '',
-        isCaseSensitive,
-        isWholeWords,
-        isRegex,
-        emptyText,
-        replaceValue,
-        getSearchIndex,
-        ...restProps
-    } = props;
-
-    if (value && !data.length) {
-        // empty search result
-        return <Empty title={emptyText} />;
-    }
+    const { data = [], onSelectNode, renderTitle } = props;
 
     return (
         <Tree
             showLine
             defaultExpandAll
+            draggable={false}
             className={treeContentClassName}
             data={data}
-            renderTitle={(node, _, isLeaf) => {
-                const { name = '' } = node;
-                if (!isLeaf) {
-                    return name;
-                }
-                const searchIndex = getSearchIndex(name, value);
-                const beforeStr = name.substr(0, searchIndex);
-                const currentValue = name.substr(searchIndex, value?.length);
-                const afterStr = name.substr(searchIndex + value?.length);
-                const title =
-                    searchIndex > -1 ? (
-                        <span>
-                            {beforeStr}
-                            <span
-                                className={classNames(
-                                    matchSearchValueClassName,
-                                    replaceValue && deleteSearchValueClassName
-                                )}
-                            >
-                                {currentValue}
-                            </span>
-                            {replaceValue && (
-                                <span className={replaceSearchValueClassName}>
-                                    {replaceValue}
-                                </span>
-                            )}
-                            {afterStr}
-                        </span>
-                    ) : (
-                        name
-                    );
-                return title;
-            }}
-            onSelectNode={folderTreeController.onSelectFile}
-            {...restProps}
+            renderTitle={renderTitle}
+            onSelectNode={onSelectNode}
         />
     );
 };

--- a/stories/extensions/test/index.tsx
+++ b/stories/extensions/test/index.tsx
@@ -122,5 +122,40 @@ export const ExtendTestPane: IExtension = {
                 })
             );
         });
+
+        molecule.search.onSearch((value) => {
+            const children = new Array(5).fill(1).map((_, index) => ({
+                key: index.toFixed(),
+                isLeaf: true,
+                name: `${value}-${index}`,
+            }));
+
+            molecule.search.setResult(
+                value
+                    ? [
+                          {
+                              key: 'molecule',
+                              name: 'molecule.test.js',
+                              isLeaf: false,
+                              children,
+                          },
+                      ]
+                    : []
+            );
+
+            molecule.search.setValidateInfo(
+                value
+                    ? {
+                          type: 'warning',
+                          text:
+                              '结果集仅包含所有匹配项的子集，请使你的搜索更加精准',
+                      }
+                    : ''
+            );
+        });
+
+        molecule.search.onResultClick((item) => {
+            console.log('item:', item);
+        });
     },
 };


### PR DESCRIPTION
### 简介
- 重构搜索模块的 UI 组件
- 重构搜索模块的 controller 和 service 模块
- 重构搜索模块的 model

### 主要变更
- `search.model` 新增 `result`，用来存储搜索结果
- 重构搜索的逻辑链路，目前逻辑链路为
    - `input` or `replace` or `icon` 的 UI 交互触发 `beforeSearch`
    - `beforeSearch` 触发内置的 `validate` 行为
    - `validate` 通过校验，则触发 `onSearch`，否则不触发
    - 用户通过 `molecule.search.onSearch` 监听 `search` 事件后，可以拿到 values 的值，并根据自己需求做搜索算法
    - 搜索完成后，通过 `molecule.search.setResult` 将搜索结果放入 `search` 中，`search` 负责渲染
- 新增 `onSearch`、`onChange`、`onResultClick`、`onReplaceAll` 事件
- `service` 方法支持注解
- 优化 `service` 中的方法，不必要的方法放入 `controller` 中
- 优化方法命名

### Related Issues
Closed #285 
Closed #286 