### PR TITLE
WIP: refactor: collapse item support resize

### DIFF
--- a/src/components/collapse/index.tsx
+++ b/src/components/collapse/index.tsx
@@ -1,6 +1,4 @@
-import * as React from 'react';
-import { useState } from 'react';
-import Logger from 'mo/common/logger';
+import React, { useState } from 'react';
 import { Toolbar } from 'mo/components/toolbar';
 import { Icon } from 'mo/components/icon';
 import { IActionBarItemProps } from 'mo/components/actionBar';
@@ -13,7 +11,10 @@ import {
     collapseExtraClassName,
     collapseContentClassName,
 } from './base';
-import { select } from 'mo/common/dom';
+import SplitPane from 'react-split-pane';
+import Pane from 'react-split-pane/lib/Pane';
+import { searchById } from 'mo/services/helper';
+import logger from 'mo/common/logger';
 
 type RenderFunctionProps = (data: DataBaseProps) => React.ReactNode;
 export interface DataBaseProps {
@@ -23,23 +24,16 @@ export interface DataBaseProps {
     hidden?: boolean;
     toolbar?: IActionBarItemProps[];
     renderPanel?: RenderFunctionProps;
-
-    // detect the collapse panel whether empty
-    _isEmpty?: boolean;
     config?: {
-        /**
-         * Specify how much of the remaining space should be assigned to the item, default is 1
-         *
-         * It unfolds in its own content height or the `MAX_GROW_HEIGHT` rather than in calculated height
-         */
-        grow?: number;
+        size?: string;
+        resizable?: boolean;
     };
 
     [key: string]: any;
 }
 
 export interface ICollapseProps {
-    data?: Partial<DataBaseProps>[];
+    data?: DataBaseProps[];
     className?: string;
     onCollapseChange?: (keys: React.Key[]) => void;
     onToolbarClick?: (
@@ -49,16 +43,13 @@ export interface ICollapseProps {
 }
 
 // default collapse height, only contains header
-export const HEADER_HEIGTH = 26;
-/**
- * It's the max height for the item which set the grow to 0
- */
-export const MAX_GROW_HEIGHT = 220;
+export const HEADER_HEIGTH = 22;
 
 export function Collapse(props: ICollapseProps) {
     const [activePanelKeys, setActivePanelKeys] = useState<React.Key[]>([]);
     const wrapper = React.useRef<HTMLDivElement>(null);
-    const requestAF = React.useRef<number>();
+    const sizesCache = React.useRef<string[]>([]);
+    const splitPane = React.useRef<any>(null);
 
     const {
         className,
@@ -68,85 +59,33 @@ export function Collapse(props: ICollapseProps) {
         ...restProps
     } = props;
 
-    const visibleData = data.filter((d) => !d.hidden);
-
-    // assets data must have id
-    const filterData = visibleData.filter(
-        (panel) => panel.id
-    ) as DataBaseProps[];
-    if (filterData.length < visibleData.length) {
-        Logger.warn(new SyntaxError('collapse data must have id'));
-    }
-
-    // to save position temporarily, empty array when rerender
-    const _cachePosition: number[][] = [];
-    let _cacheWrapperHeight = React.useRef(0);
-
-    const handleResize = React.useCallback(() => {
-        // just want to trigger rerender
-        setActivePanelKeys((keys) => keys.concat());
-    }, []);
-
-    React.useEffect(() => {
-        window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
-    }, []);
-
-    React.useLayoutEffect(() => {
-        // It's necessary to check panel's empty before calculate every panel
-        filterData.forEach((panel) => {
-            const isActive = activePanelKeys.includes(panel.id);
-            let isEmpty = true;
-            if (isActive) {
-                const contentDom =
-                    select(
-                        `.${collapseContentClassName}[data-content='${panel.id}']`
-                    )?.querySelector(`[data-content='${panel.id}']`) ||
-                    select(
-                        `.${collapseContentClassName}[data-content='${panel.id}']`
-                    );
-
-                isEmpty = !contentDom?.hasChildNodes();
-            }
-            panel._isEmpty = isEmpty;
-        });
-
-        filterData.forEach((panel) => {
-            const [height, top] = calcPosition(
-                activePanelKeys,
-                panel,
-                filterData
-            );
-            _cachePosition.push([height, top]);
-            const dom = select<HTMLElement>(
-                `.${collapseItemClassName}[data-content='${panel.id}']`
-            );
-
-            if (dom) {
-                requestAF.current = requestAnimationFrame(() => {
-                    dom.style.height = `${height}px`;
-                    dom.style.top = `${top}px`;
-                });
-            }
-        });
-
-        return () => {
-            if (requestAF.current) {
-                cancelAnimationFrame(requestAF.current);
-                requestAF.current = undefined;
-            }
-        };
-    }, [filterData]);
-
     const handleChangeCallback = (key: React.Key) => {
+        const splitPaneRef = splitPane.current;
         const currentKeys = activePanelKeys.concat();
+        const sizes = splitPaneRef.getSizes();
+        const index = data.findIndex(searchById(key));
         if (currentKeys.includes(key)) {
             currentKeys.splice(currentKeys.indexOf(key), 1);
+            if (index > -1) {
+                sizes[index] = `${HEADER_HEIGTH}px`;
+            }
         } else {
             currentKeys.push(key);
+            if (index > -1) {
+                const currentSize = sizesCache.current[index];
+                const size = data[index].config?.size || '1';
+                sizes[index] =
+                    size === 'auto' ? `0 0 auto` : currentSize || size;
+            }
         }
         onCollapseChange?.(currentKeys);
         setActivePanelKeys(currentKeys);
+
+        requestAnimationFrame(() => {
+            splitPaneRef.setState({
+                sizes,
+            });
+        });
     };
 
     const handleToolbarClick = (
@@ -168,176 +107,41 @@ export function Collapse(props: ICollapseProps) {
         return null;
     };
 
-    /**
-     * Returns the grow of data, or 1
-     */
-    const getGrow = (data: DataBaseProps) => {
-        if (typeof data.config?.grow === 'number') {
-            return data.config.grow;
-        } else {
-            return 1;
-        }
-    };
+    React.useLayoutEffect(() => {
+        const collapse = wrapper.current;
+        const splitPaneRef = splitPane.current;
 
-    /**
-     * Returns the key whose panel is active and whose grow is 0
-     */
-    const getZeroPanelsByKeys = (
-        keys: React.Key[],
-        panels: DataBaseProps[]
-    ) => {
-        return keys.filter((key) => {
-            const targetPanel = panels.find((panel) => panel.id === key);
-            if (targetPanel) {
-                return targetPanel.config?.grow === 0;
-            }
-            return false;
-        });
-    };
+        if (collapse && splitPaneRef) {
+            const panes = collapse.querySelectorAll<HTMLDivElement>('.pane');
 
-    /**
-     * Returns the collections of height
-     */
-    const getContentHeightsByKeys = (data: React.Key[]) => {
-        return data.map((key) => {
-            const contentDom = select(
-                `.${collapseContentClassName}[data-content='${key}']`
-            );
+            panes.forEach((pane) => {
+                const resizer = pane.nextSibling as HTMLDivElement | null;
+                if (resizer) {
+                    const nextSibling = resizer.nextSibling as HTMLDivElement | null;
+                    // Only sibling of two side both can resize, the resizer could work
+                    const isDisabled =
+                        pane.className.includes('disabled') ||
+                        nextSibling?.className.includes('disabled');
 
-            const childrenDom = contentDom?.querySelector(
-                `[data-content='${key}']`
-            );
-
-            let contentHeight = contentDom?.getBoundingClientRect().height || 0;
-
-            if (childrenDom) {
-                contentHeight = childrenDom.getBoundingClientRect().height;
-            }
-
-            // border-top-width + border-bottom-width = 2
-            const height =
-                parseInt(contentHeight.toFixed(0)) - 2 + HEADER_HEIGTH;
-
-            return height > MAX_GROW_HEIGHT ? MAX_GROW_HEIGHT : height;
-        });
-    };
-
-    /**
-     * Calculate the position of the panel in view
-     * @param keys Current active keys
-     * @param panel Current panel
-     * @param panels All panels array
-     * @returns Tuple - [height, top]
-     */
-    const calcPosition = (
-        keys: React.Key[],
-        panel: DataBaseProps,
-        panels: DataBaseProps[]
-    ) => {
-        // init a Tuple save height and top
-        const res = [0, 0];
-        const isActive = keys.includes(panel.id);
-        // calculate height for current panel
-        if (!isActive || panel._isEmpty) {
-            // the height of inactive panel or empty panel is a fixed value
-            res[0] = HEADER_HEIGTH;
-        } else {
-            if (panel.config?.grow === 0) {
-                // to get current panel content
-                const contentDom = select(
-                    `.${collapseContentClassName}[data-content='${panel.id}']`
-                )?.querySelector(`[data-content='${panel.id}']`);
-
-                if (contentDom) {
-                    const height =
-                        contentDom.getBoundingClientRect().height +
-                        2 +
-                        HEADER_HEIGTH;
-                    res[0] =
-                        height > MAX_GROW_HEIGHT ? MAX_GROW_HEIGHT : height;
+                    resizer.style.cursor = isDisabled
+                        ? 'initial'
+                        : 'row-resize';
+                    resizer.style.pointerEvents = isDisabled ? 'none' : 'auto';
                 }
-            } else {
-                // get the height of the wrapper
-                let wrapperHeight =
-                    wrapper.current?.getBoundingClientRect().height ||
-                    _cacheWrapperHeight.current;
-                _cacheWrapperHeight.current = wrapperHeight;
-                // count active panels
-                const activeCount = keys.length;
-                const inactiveCount = panels.length - activeCount;
-                // the height active panels can occupied
-                wrapperHeight = wrapperHeight - HEADER_HEIGTH * inactiveCount;
-
-                // get grow-zero panels' heights
-                const growZeroPanelsKeys = getZeroPanelsByKeys(keys, panels);
-                const growZeroPanelsHeights = getContentHeightsByKeys(
-                    growZeroPanelsKeys
-                );
-
-                // the height grow-normal panels can occupied =
-                // the height active panels can occupied -
-                // each grow-zero panels' heights
-                growZeroPanelsHeights.forEach((height) => {
-                    wrapperHeight -= height;
-                });
-
-                // count the non-empty & active & non-grow-zero panels in active panels
-                const nonEmptyAndActivePanels: DataBaseProps[] = [];
-                const nonEmptyAndActivePanelKeys = keys.filter((key) => {
-                    const target = panels.find((p) => p.id === key);
-                    if (target) {
-                        if (getGrow(target) === 0) return false;
-                        if (typeof target._isEmpty === 'boolean') {
-                            !target._isEmpty &&
-                                nonEmptyAndActivePanels.push(target);
-                            return !target._isEmpty;
-                        }
-                        // In general, the following code will not be excuted
-                        const contentDom = select(
-                            `.${collapseContentClassName}[data-content='${panel.id}']`
-                        )?.querySelector(`[data-content='${panel.id}']`);
-                        return contentDom?.hasChildNodes();
-                    }
-                    return false;
-                });
-
-                const growSum = nonEmptyAndActivePanels.reduce((pre, cur) => {
-                    return pre + getGrow(cur);
-                }, 0);
-
-                const emptyAndActivePanelsHeights =
-                    HEADER_HEIGTH *
-                    (keys.length -
-                        growZeroPanelsKeys.length -
-                        nonEmptyAndActivePanelKeys.length);
-
-                // the height for grow-normal panels is divided by non-empty & active & grow-normal panels depends on grow number
-                res[0] =
-                    ((wrapperHeight - emptyAndActivePanelsHeights) *
-                        getGrow(panel)) /
-                    growSum;
-            }
+            });
         }
+    }, [activePanelKeys]);
 
-        // calculate top for current panel
-        let topCount = 0;
-        for (let index = 0; index < panels.length; index++) {
-            const element = panels[index];
-            // only count the position of front panel
-            if (element === panel) {
-                break;
+    const handleChange = (values: string[]) => {
+        data.forEach((item, index) => {
+            if (item.config?.size === 'auto') {
+                values[index] = '0 0 auto';
             }
-            // if this element is a active panel, then get height via cache
-            // else count default height in
-            if (keys.includes(element.id)) {
-                const [cacheHeight] = _cachePosition[index];
-                topCount += cacheHeight;
-            } else {
-                topCount += HEADER_HEIGTH;
-            }
-        }
-        res[1] = topCount;
-        return res;
+        });
+    };
+
+    const handleResizeEnd = (values: string[]) => {
+        sizesCache.current = values.concat();
     };
 
     return (
@@ -346,58 +150,101 @@ export function Collapse(props: ICollapseProps) {
             ref={wrapper}
             {...restProps}
         >
-            {filterData
-                .filter((p) => !p.hidden)
-                .map((panel) => {
+            <SplitPane
+                ref={splitPane}
+                split="horizontal"
+                // @ts-ignore
+                onChange={handleChange}
+                // @ts-ignore
+                onResizeEnd={handleResizeEnd}
+            >
+                {data.map((panel, index) => {
+                    if (!panel.id) {
+                        logger.warn(
+                            'Please make sure the children of collapse must have id'
+                        );
+                        return null;
+                    }
+                    const sizes = splitPane.current?.getSizes() || [];
+                    if (panel.hidden)
+                        return (
+                            <Pane
+                                key={panel.id}
+                                initialSize={sizes[index]}
+                                maxSize="0px"
+                            ></Pane>
+                        );
+
                     const isActive = activePanelKeys.includes(panel.id);
+                    const resizable =
+                        typeof panel.config?.resizable === 'undefined'
+                            ? true
+                            : panel.config?.resizable;
+
                     return (
-                        <div
-                            className={classNames(
-                                collapseItemClassName,
-                                isActive && collapseActiveClassName
-                            )}
-                            data-content={panel.id}
+                        <Pane
+                            className={classNames('pane', {
+                                disabled: !isActive || !resizable,
+                            })}
                             key={panel.id}
+                            initialSize={sizes[index] || `${HEADER_HEIGTH}px`}
+                            minSize={`${HEADER_HEIGTH}px`}
                         >
                             <div
-                                className={collapseHeaderClassName}
-                                tabIndex={0}
-                                onClick={() => handleChangeCallback(panel.id)}
+                                className={classNames(
+                                    collapseItemClassName,
+                                    isActive && collapseActiveClassName
+                                )}
                             >
-                                <Icon
-                                    type={
-                                        isActive
-                                            ? 'chevron-down'
-                                            : 'chevron-right'
+                                <div
+                                    className={collapseHeaderClassName}
+                                    tabIndex={0}
+                                    style={{
+                                        borderTop:
+                                            index === 0 ? 'none' : undefined,
+                                    }}
+                                    onClick={() =>
+                                        handleChangeCallback(panel.id)
                                     }
-                                />
-                                {panel.name}
-                                <div className={collapseExtraClassName}>
-                                    {isActive && (
-                                        <Toolbar
-                                            key={panel.id}
-                                            data={panel.toolbar || []}
-                                            onClick={(e, item) =>
-                                                handleToolbarClick(
-                                                    e,
-                                                    item,
-                                                    panel
-                                                )
-                                            }
-                                        />
+                                >
+                                    <Icon
+                                        type={
+                                            isActive
+                                                ? 'chevron-down'
+                                                : 'chevron-right'
+                                        }
+                                    />
+                                    {panel.name}
+                                    <div className={collapseExtraClassName}>
+                                        {isActive && (
+                                            <Toolbar
+                                                key={panel.id}
+                                                data={panel.toolbar || []}
+                                                onClick={(e, item) =>
+                                                    handleToolbarClick(
+                                                        e,
+                                                        item,
+                                                        panel
+                                                    )
+                                                }
+                                            />
+                                        )}
+                                    </div>
+                                </div>
+                                <div
+                                    className={classNames(
+                                        collapseContentClassName,
+                                        isActive && 'active'
                                     )}
+                                    tabIndex={0}
+                                >
+                                    {renderPanels(panel, panel.renderPanel)}
                                 </div>
                             </div>
-                            <div
-                                className={collapseContentClassName}
-                                data-content={panel.id}
-                                tabIndex={0}
-                            >
-                                {renderPanels(panel, panel.renderPanel)}
-                            </div>
-                        </div>
+                        </Pane>
                     );
                 })}
+            </SplitPane>
         </div>
     );
 }

--- a/src/components/collapse/style.scss
+++ b/src/components/collapse/style.scss
@@ -6,20 +6,13 @@ $collapse__extra: #{$collapse}__extra;
     height: 100%;
     position: relative;
 
-    &:focus-within {
-        #{$collapse__extra} {
-            opacity: 1;
-        }
+    .pane {
+        transition: all ease-in-out 0.3s;
     }
 
     &__item {
-        border-bottom: 1px solid var(--sideBarSectionHeader-border);
-        display: flex;
-        flex-direction: column;
-        line-height: 22px;
+        height: 100%;
         overflow: hidden;
-        position: absolute;
-        transition: top ease-in-out 0.2s, height ease-in-out 0.2s;
         width: 100%;
 
         &:hover {
@@ -27,27 +20,31 @@ $collapse__extra: #{$collapse}__extra;
                 opacity: 1;
             }
         }
-
-        &:last-child {
-            border-bottom-color: transparent;
-        }
     }
 
     &__header {
         align-items: center;
-        border: 1px solid transparent;
+        border-top: 1px solid var(--sideBarSectionHeader-border);
         box-sizing: border-box;
         cursor: pointer;
         display: flex;
         font-size: 11px;
-        font-weight: bold;
-        height: 25px;
-        outline: none;
-        padding: 1px 2px;
+        font-weight: 700;
+        height: 22px;
+        outline-color: transparent;
+        outline-offset: -1px;
+        outline-style: solid;
+        outline-width: 1px;
+        overflow: hidden;
+        text-transform: uppercase;
         user-select: none;
 
         &:focus {
-            border-color: var(--list-focusOutline);
+            outline-color: var(--list-focusOutline);
+
+            #{$collapse__extra} {
+                opacity: 1;
+            }
         }
     }
 
@@ -62,15 +59,24 @@ $collapse__extra: #{$collapse}__extra;
     }
 
     &__content {
-        border: 1px solid transparent;
-        width: calc(100% - 3px);
+        max-height: 0;
+        outline-color: transparent;
+        outline-offset: -1px;
+        outline-style: solid;
+        outline-width: 1px;
+        transition: max-height ease-in-out 0.3s;
 
         &:not(:empty) {
-            flex: 1;
+            height: calc(100% - 22px);
+            padding: 1px;
         }
 
         &:focus {
-            border-color: var(--list-focusOutline);
+            outline-color: var(--list-focusOutline);
+        }
+
+        &.active {
+            max-height: 100vh;
         }
     }
 }

--- a/src/model/workbench/explorer/explorer.tsx
+++ b/src/model/workbench/explorer/explorer.tsx
@@ -113,7 +113,8 @@ export function builtInExplorerEditorPanel() {
             },
         ],
         config: {
-            grow: 0,
+            size: 'auto',
+            resizable: false,
         },
     };
 }
@@ -168,7 +169,7 @@ export function builtInExplorerFolderPanel() {
             },
         ],
         config: {
-            grow: 2,
+            size: '2',
         },
     };
 }

--- a/src/workbench/sidebar/explore/editorTree.tsx
+++ b/src/workbench/sidebar/explore/editorTree.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import { IEditorTreeController } from 'mo/controller';
 import {
     EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS,
@@ -29,15 +29,17 @@ import {
 import { classNames } from 'mo/common/className';
 import { getEventPosition } from 'mo/common/dom';
 import { localize } from 'mo/i18n/localize';
-import {
-    DataBaseProps,
-    HEADER_HEIGTH,
-    MAX_GROW_HEIGHT,
-} from 'mo/components/collapse';
+import { DataBaseProps, HEADER_HEIGTH } from 'mo/components/collapse';
 import Scrollbar from 'react-scrollbars-custom';
 
 // override onContextMenu
 type UnionEditor = Omit<IEditor & IEditorTreeController, 'onContextMenu'>;
+
+/**
+ * It's the max height for the item which set the grow to 0
+ */
+const MAX_GROW_HEIGHT = 220;
+
 export interface IOpenEditProps extends UnionEditor {
     /**
      * Group Header toolbar
@@ -77,6 +79,7 @@ const EditorTree = (props: IOpenEditProps) => {
 
     const wrapper = useRef<HTMLDivElement>(null);
     const scrollable = useRef<Scrollbar>(null);
+    const [height, setHeight] = useState(0);
 
     // scroll into view
     useLayoutEffect(() => {
@@ -90,6 +93,9 @@ const EditorTree = (props: IOpenEditProps) => {
                 scrollable.current?.scrollTo(0, top);
             }
         }
+
+        const height = wrapper.current?.getBoundingClientRect().height || 0;
+        setHeight(height > MAX_GROW_HEIGHT ? MAX_GROW_HEIGHT : height);
     }, [current?.id && current.tab?.id]);
 
     if (!groups || !groups.length) return null;
@@ -173,7 +179,14 @@ const EditorTree = (props: IOpenEditProps) => {
     };
 
     return (
-        <Scrollable noScrollX isShowShadow ref={scrollable}>
+        <Scrollable
+            style={{
+                height,
+            }}
+            noScrollX
+            isShowShadow
+            ref={scrollable}
+        >
             <div
                 className={editorTreeClassName}
                 ref={wrapper}


### PR DESCRIPTION
### 简介
- collapse 支持 resize 大小
- 重构 collapse 的位置计算

### 主要变更
- 基于 `react-split-pane` 实现拖拽修改大小的功能，但是该组件库无人维护状态，`bug` 甚多，要考虑以后如果要改或者新增功能的话，该组件很难很好的满足需求
- 由于 `react-split-pane` 是基于 `flex` 实现的，那就可以借助 flex 来对位置做调整，就不再需要去实时计算位置，从而节省渲染时间