### PR TITLE
fix: setting config not working when deleting property

### DIFF
--- a/src/controller/settings.ts
+++ b/src/controller/settings.ts
@@ -9,7 +9,12 @@ import {
     PanelService,
     SettingsService,
 } from 'mo/services';
-import { SettingsEvent, BuiltInSettingsTab } from 'mo/model/settings';
+import {
+    SettingsEvent,
+    BuiltInSettingsTab,
+    initialEditorSetting,
+    initialWorkbenchSetting,
+} from 'mo/model/settings';
 
 export interface ISettingsController {}
 
@@ -37,6 +42,11 @@ export class SettingsController
                 const config = this.settingsService.normalizeFlatObject(
                     tab.data?.value || ''
                 );
+                config.editor = { ...initialEditorSetting, ...config.editor };
+                config.workbench = {
+                    ...initialWorkbenchSetting,
+                    ...config.workbench,
+                };
                 this.settingsService.update(config);
             }
         });

--- a/src/model/settings.ts
+++ b/src/model/settings.ts
@@ -17,11 +17,11 @@ export enum SettingsEvent {
     OnChange = 'settings.onchange',
 }
 
-const initialWorkbenchSetting = {
+export const initialWorkbenchSetting = {
     colorTheme: 'Default Dark+',
 };
 
-const initialEditorSetting: IEditorSettings = {
+export const initialEditorSetting: IEditorSettings = {
     renderWhitespace: 'none',
     tabSize: 4,
     fontSize: 14,
@@ -47,8 +47,8 @@ export class SettingsModel implements ISettings {
     editor: IEditorSettings;
 
     constructor(
-        workbench: IWorkbenchSettings = initialWorkbenchSetting,
-        editor: IEditorSettings = initialEditorSetting
+        workbench: IWorkbenchSettings = { ...initialWorkbenchSetting },
+        editor: IEditorSettings = { ...initialEditorSetting }
     ) {
         this.workbench = workbench;
         this.editor = editor;


### PR DESCRIPTION
### 简介
- 修复删除内置设置的时候，该值不会还原成默认值的问题

### 主要变更
- 当获取到 `setting` 中的值后，再和 init 的值做一次 `assign` 

### Related Issues
Closed #280 