### PR TITLE
refactor(monaco): remove useless props

### DIFF
--- a/src/components/monaco/index.tsx
+++ b/src/components/monaco/index.tsx
@@ -11,14 +11,9 @@ export const SYMBOL_MONACO_EDITOR = `${APP_PREFIX}-monaco-editor`;
 
 export interface IMonacoEditorProps extends React.ComponentProps<any> {
     /**
-     * The value of monaco editor
-     */
-    value?: string;
-    /**
      * The option of monaco editor
      */
     options?: editor.IStandaloneEditorConstructionOptions;
-    path?: string;
     /**
      * The override for monaco editor
      */


### PR DESCRIPTION
## 简介

Monaco editor 的单测

## 主要变更

删除无效的传参，故暂时没有单测需要写