### PR TITLE
fix: improve type definition of editor tab

### DIFF
--- a/src/model/workbench/editor.ts
+++ b/src/model/workbench/editor.ts
@@ -22,6 +22,8 @@ interface BuiltInEditorTabDataType {
     path?: string;
     value?: string;
     modified?: boolean;
+
+    [key: string]: any;
 }
 
 export interface IEditorActionsProps extends IMenuItemProps {


### PR DESCRIPTION
### 简介
- 修复 editor 的 tab 类型定义，不加 key 的话，用户在 `tab.data` 中添加自己的数据的时候，会有 ts 的报错