### PR TITLE
fix: prevent page broken via folderTree

### DIFF
--- a/src/services/helper.ts
+++ b/src/services/helper.ts
@@ -127,7 +127,7 @@ export class TreeViewUtil<T extends BaseProps> implements ITreeInterface<T> {
             const parentIndex = this.getIndex(index.parent!);
             const parentNode = this.get(index.parent!);
 
-            if (parentNode && parentIndex) {
+            if (parentNode && parentIndex && parentIndex[this.childNodeName]) {
                 parentNode[this.childNodeName].splice(
                     parentNode[this.childNodeName].indexOf(node),
                     1
@@ -167,7 +167,7 @@ export class TreeViewUtil<T extends BaseProps> implements ITreeInterface<T> {
         return null;
     }
 
-    updateChildren(children: IIndex<T>) {
+    updateChildren(children: IIndex<T> = []) {
         const self = this;
         children.forEach(function (id, i) {
             const index = self.getIndex(id);


### PR DESCRIPTION
### 简介
- 优化 helper 代码，防止由于相同 id 导致寻找树节点失败，进而导致页面崩溃的问题


### 主要变更
- 添加非空判断

### Related  Issues
Closed #357 