### PR TITLE
fix: prevent page broken when data is undefined

### DIFF
--- a/src/workbench/sidebar/explore/editorTree.tsx
+++ b/src/workbench/sidebar/explore/editorTree.tsx
@@ -216,7 +216,7 @@ const EditorTree = (props: IOpenEditProps) => {
                                     file.id === current?.tab?.id;
                                 return (
                                     <div
-                                        title={`${file.data.path}/${file.name}`}
+                                        title={`${file.data?.path}/${file.name}`}
                                         className={classNames(
                                             editorTreeItemClassName,
                                             isActive &&


### PR DESCRIPTION
### 简介
- 防止新建 tree 的时候由于没有 data 属性，导致页面崩溃