### PR TITLE
refactor: rename logErrorFn to expectLoggerErrorToBeCalled

### DIFF
--- a/src/services/__tests__/activityBarService.test.ts
+++ b/src/services/__tests__/activityBarService.test.ts
@@ -3,7 +3,7 @@ import { container } from 'tsyringe';
 import { ActivityBarService } from '../workbench';
 import { ActivityBarEvent, IActivityBarItem } from 'mo/model';
 import type { IMenuItemProps } from 'mo/components';
-import { logErrorFn } from '@test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 
 const activityBarService = container.resolve(ActivityBarService);
 
@@ -55,7 +55,7 @@ describe('The ActivityBar Services', () => {
     });
 
     test('Should log error when remove failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             activityBarService.remove('1');
         });
     });
@@ -70,7 +70,7 @@ describe('The ActivityBar Services', () => {
     });
 
     test('Should log error when toggleBar failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             activityBarService.toggleBar('1');
         });
     });
@@ -126,7 +126,7 @@ describe('The ActivityBar Services', () => {
     });
 
     test('Should log error when toggle the status failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             activityBarService.toggleContextMenuChecked('1');
         });
     });
@@ -140,7 +140,7 @@ describe('The ActivityBar Services', () => {
     });
 
     test('Should log error when remove context menus failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             activityBarService.removeContextMenu('1');
         });
     });

--- a/src/services/__tests__/colorThemeService.test.ts
+++ b/src/services/__tests__/colorThemeService.test.ts
@@ -1,6 +1,6 @@
 import { cleanup } from '@testing-library/react';
 import 'reflect-metadata';
-import { logErrorFn } from '@test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 import { container } from 'tsyringe';
 import {
     BuiltInColorTheme,
@@ -86,7 +86,7 @@ describe('The Color Theme Service', () => {
     });
 
     test('Should log error when set unrecognized theme', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             colorThemeService.setTheme(DarkTestTheme.id);
         });
     });
@@ -119,7 +119,7 @@ describe('The Color Theme Service', () => {
     });
 
     test('Should have log error message without id when update theme', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             colorThemeService.updateTheme({
                 ...BuiltInColorTheme,
                 label: 'Dark Test',
@@ -129,7 +129,7 @@ describe('The Color Theme Service', () => {
     });
 
     test('Should have log error message with no found theme', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             colorThemeService.updateTheme(DarkTestTheme);
         });
     });

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,6 +1,6 @@
 import { NotificationStatus } from 'mo/model';
 import 'reflect-metadata';
-import { logErrorFn } from '@test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 import { container } from 'tsyringe';
 import { NotificationService } from '..';
 
@@ -44,13 +44,13 @@ describe('The Notification Service', () => {
     });
 
     test('Should check notification before remove', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             notificationService.remove(1);
         });
     });
 
     test("Should log error when did't find the notification", () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             notificationService.add([mockNotice]);
             notificationService.remove(2);
         });
@@ -64,7 +64,7 @@ describe('The Notification Service', () => {
     });
 
     test('Should check params valid before update notifications', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             let result = notificationService.update(mockNotice);
             expect(result).toBeNull();
 

--- a/src/services/__tests__/panelService.test.ts
+++ b/src/services/__tests__/panelService.test.ts
@@ -8,7 +8,7 @@ import {
     PanelEvent,
 } from 'mo/model/workbench/panel';
 import { builtInPanelProblems } from 'mo/model/problems';
-import { logErrorFn } from '@test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 
 const paneOutput = builtInOutputPanel();
 const panelProblems = builtInPanelProblems();
@@ -53,7 +53,7 @@ describe('The PanelService test', () => {
 
     test('Should log error when remove the panel failed', () => {
         let removed;
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             removed = panelService.remove(paneOutput.id);
         });
 
@@ -115,7 +115,7 @@ describe('The PanelService test', () => {
 
     test('Should log error when update failed', () => {
         let updated;
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             updated = panelService.update({
                 id: paneOutput.id,
                 data: 'test',
@@ -146,7 +146,7 @@ describe('The PanelService test', () => {
         const state = panelService.getState();
         expect(state.current).toBeNull();
 
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             panelService.setActive(paneOutput.id);
         });
 

--- a/src/services/__tests__/problemsService.test.ts
+++ b/src/services/__tests__/problemsService.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { logErrorFn } from '@test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 import { container } from 'tsyringe';
 import { ProblemsService } from '../problemsService';
 
@@ -119,7 +119,7 @@ describe('The Problems Service', () => {
     });
 
     test("Should log error when didn't find the problem in remove", () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             problemsService.add([mockData]);
             problemsService.remove(2);
         });
@@ -166,7 +166,7 @@ describe('The Problems Service', () => {
     });
 
     test("Should log error when didn't find the problem in update", () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             problemsService.add([mockData]);
             problemsService.update({ ...mockData, id: 2 });
         });

--- a/src/services/__tests__/sidebarService.test.ts
+++ b/src/services/__tests__/sidebarService.test.ts
@@ -1,6 +1,6 @@
 import type { ISidebarPane } from 'mo/model';
 import 'reflect-metadata';
-import { logErrorFn } from '@test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 import { container } from 'tsyringe';
 import { SidebarService } from '../workbench';
 
@@ -35,7 +35,7 @@ describe('The Sidebar Service', () => {
     });
 
     test('Should log error when add failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             sidebarService.add(mockSide);
             sidebarService.add(mockSide);
         });
@@ -64,7 +64,7 @@ describe('The Sidebar Service', () => {
     });
 
     test('Should log error when setActive failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             sidebarService.setActive(mockSide.id);
         });
     });
@@ -86,7 +86,7 @@ describe('The Sidebar Service', () => {
     });
 
     test('Should log error when update failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             sidebarService.update({
                 id: mockSide.id,
                 title: 'update-title',
@@ -123,7 +123,7 @@ describe('The Sidebar Service', () => {
     });
 
     test('Should log error when remove failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             sidebarService.remove(mockSide.id);
         });
     });

--- a/src/services/__tests__/statusBarService.test.ts
+++ b/src/services/__tests__/statusBarService.test.ts
@@ -10,7 +10,7 @@ import {
     StatusBarEvent,
     STATUS_EDITOR_INFO,
 } from 'mo/model/workbench/statusBar';
-import { logErrorFn } from '../../../test/utils';
+import { expectLoggerErrorToBeCalled } from '@test/utils';
 
 const mockStatusData = {
     ...STATUS_EDITOR_INFO,
@@ -56,7 +56,7 @@ describe('Test StatusBarService', () => {
     });
 
     test('Should log error when add failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             // there is a status item whose id is ${mockStatusData.id}, so it'll add failed
             statusBarService.add(mockStatusData, Float.right);
         });
@@ -103,7 +103,7 @@ describe('Test StatusBarService', () => {
     });
 
     test('Should log error when update failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             statusBarService.update({
                 id: anotherStatusData.id,
                 sortIndex: 1,
@@ -150,7 +150,7 @@ describe('Test StatusBarService', () => {
     });
 
     test('Should log error when remove failed', () => {
-        logErrorFn(() => {
+        expectLoggerErrorToBeCalled(() => {
             statusBarService.remove(anotherStatusData.id);
         });
     });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,8 +1,9 @@
 import logger from 'mo/common/logger';
+
 /**
- * Test the action whether log error
+ * Expect the `logger.error` method to be called when exec action
  */
-export function logErrorFn(action: () => void) {
+export function expectLoggerErrorToBeCalled(action: () => void) {
     const originalLog = logger.error;
     logger.error = jest.fn();
 
@@ -12,6 +13,10 @@ export function logErrorFn(action: () => void) {
     logger.error = originalLog;
 }
 
+/**
+ * Expect the `testFn` function to be called when exec action
+ * @param action
+ */
 export function expectFnCalled(
     action: (testFn: (...args: any) => void) => void
 ) {


### PR DESCRIPTION
### 简介
- 重命名测试函数