### PR TITLE
fix: set the collapse content width to initial value

### DIFF
--- a/src/components/collapse/style.scss
+++ b/src/components/collapse/style.scss
@@ -69,7 +69,6 @@ $collapse__extra: #{$collapse}__extra;
 
     &__content {
         border: 1px solid transparent;
-        width: calc(100% - 3px);
 
         &:not(:empty) {
             flex: 1;


### PR DESCRIPTION
## Description

移除 Collapse Content 的 `width` 属性计算
