### PR TITLE
fix: remove the pointer-events CSS property

### DIFF
--- a/src/components/actionBar/style.scss
+++ b/src/components/actionBar/style.scss
@@ -24,9 +24,8 @@ $icon-size: 20px;
         margin-left: 2px;
 
         &--disabled {
-            cursor: default;
+            cursor: not-allowed;
             opacity: 0.4;
-            pointer-events: none;
         }
 
         .codicon {


### PR DESCRIPTION
## Description

移除多余的 pointer-events 属性，导致鼠标 hover 事件也被禁用，无法触发 Tooltip 效果