### PR TITLE
feat: add built-in service for explorer

### DIFF
--- a/src/components/actionBar/index.tsx
+++ b/src/components/actionBar/index.tsx
@@ -130,15 +130,18 @@ export function ActionBar<T = any>(props: IActionBarProps<T>) {
 
     const claNames = classNames(defaultActionBarClassName, className);
 
-    const items = data.map((item: IActionBarItemProps<T>, index) => (
-        <ActionBarItem
-            key={item.id}
-            {...item}
-            onContextMenuClick={onContextMenuClick}
-            data-index={index}
-            onClick={mergeFunctions(onClick, item.onClick)}
-        />
-    ));
+    const items = data.map(
+        (item: IActionBarItemProps<T>, index) =>
+            item.id && (
+                <ActionBarItem
+                    key={item.id}
+                    {...item}
+                    onContextMenuClick={onContextMenuClick}
+                    data-index={index}
+                    onClick={mergeFunctions(onClick, item.onClick)}
+                />
+            )
+    );
 
     return (
         <div className={claNames} {...custom}>

--- a/src/controller/explorer/editorTree.tsx
+++ b/src/controller/explorer/editorTree.tsx
@@ -7,9 +7,13 @@ import {
     builtInEditorTreeHeaderContextMenu,
     EditorTreeEvent,
 } from 'mo/model/workbench/explorer/editorTree';
-import { EditorService, ExplorerService } from 'mo/services';
 import {
-    builtInExplorerEditorPanel,
+    BuiltinService,
+    EditorService,
+    ExplorerService,
+    IBuiltinService,
+} from 'mo/services';
+import {
     EDITOR_MENU_CLOSE,
     EDITOR_MENU_CLOSE_ALL,
     EDITOR_MENU_CLOSE_OTHERS,
@@ -40,6 +44,8 @@ export interface IEditorTreeController {
         groupId: number,
         file?: ITabProps
     ) => void;
+
+    readonly initView: () => void;
 }
 
 @singleton()
@@ -48,12 +54,13 @@ export class EditorTreeController
     implements IEditorTreeController {
     private readonly explorerService: ExplorerService;
     private readonly editService: EditorService;
+    private readonly builtinService: IBuiltinService;
 
     constructor() {
         super();
         this.editService = container.resolve(EditorService);
         this.explorerService = container.resolve(ExplorerService);
-        this.initView();
+        this.builtinService = container.resolve(BuiltinService);
     }
 
     public initView() {
@@ -61,27 +68,30 @@ export class EditorTreeController
             this.editService,
             EditorTree
         );
-        const { groupToolbar, ...restEditor } = builtInExplorerEditorPanel();
-        const contextMenu = builtInEditorTreeContextMenu();
-        const headerContextMenu = builtInEditorTreeHeaderContextMenu();
+        const { builtInExplorerEditorPanel } = this.builtinService.getModules();
+        if (builtInExplorerEditorPanel) {
+            const { groupToolbar, ...restEditor } = builtInExplorerEditorPanel;
+            const contextMenu = builtInEditorTreeContextMenu();
+            const headerContextMenu = builtInEditorTreeHeaderContextMenu();
 
-        this.explorerService.addPanel({
-            ...restEditor,
-            renderPanel: (panel) => (
-                <EditorTreeView
-                    panel={panel}
-                    contextMenu={contextMenu}
-                    headerContextMenu={headerContextMenu}
-                    groupToolbar={groupToolbar}
-                    onClose={this.onClose}
-                    onSelect={this.onSelect}
-                    onCloseGroup={this.onCloseGroup}
-                    onSaveGroup={this.onSaveGroup}
-                    onContextMenu={this.onContextMenu}
-                    onToolbarClick={this.onToolbarClick}
-                />
-            ),
-        });
+            this.explorerService.addPanel({
+                ...restEditor,
+                renderPanel: (panel) => (
+                    <EditorTreeView
+                        panel={panel}
+                        contextMenu={contextMenu}
+                        headerContextMenu={headerContextMenu}
+                        groupToolbar={groupToolbar}
+                        onClose={this.onClose}
+                        onSelect={this.onSelect}
+                        onCloseGroup={this.onCloseGroup}
+                        onSaveGroup={this.onSaveGroup}
+                        onContextMenu={this.onContextMenu}
+                        onToolbarClick={this.onToolbarClick}
+                    />
+                ),
+            });
+        }
     }
 
     public onContextMenu = (

--- a/src/controller/explorer/explorer.tsx
+++ b/src/controller/explorer/explorer.tsx
@@ -6,21 +6,10 @@ import { connect } from 'mo/react';
 import { Explorer, FolderTreeView } from 'mo/workbench/sidebar/explore';
 import { IMenuItemProps } from 'mo/components/menu';
 import {
-    builtInExplorerActivityItem,
-    builtInExplorerFolderPanel,
     ExplorerEvent,
-    EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
-    EXPLORER_TOGGLE_SAVE_ALL,
-    EXPLORER_TOGGLE_VERTICAL,
     IExplorerPanelItem,
 } from 'mo/model/workbench/explorer/explorer';
-import {
-    NEW_FILE_COMMAND_ID,
-    NEW_FOLDER_COMMAND_ID,
-    REMOVE_COMMAND_ID,
-    FileTypes,
-    EditorTreeEvent,
-} from 'mo/model';
+import { FileTypes, EditorTreeEvent } from 'mo/model';
 import { IActionBarItemProps } from 'mo/components/actionBar';
 import {
     IExplorerService,
@@ -29,6 +18,8 @@ import {
     ActivityBarService,
     SidebarService,
     ExplorerService,
+    IBuiltinService,
+    BuiltinService,
 } from 'mo/services';
 import { FolderTreeController, IFolderTreeController } from './folderTree';
 
@@ -43,6 +34,8 @@ export interface IExplorerController {
         panel: IExplorerPanelItem
     ) => void;
     onClick?: (event, item) => void;
+
+    initView(): void;
 }
 
 @singleton()
@@ -53,6 +46,7 @@ export class ExplorerController
     private readonly sidebarService: ISidebarService;
     private readonly explorerService: IExplorerService;
     private readonly folderTreeController: IFolderTreeController;
+    private readonly builtinService: IBuiltinService;
 
     constructor() {
         super();
@@ -60,11 +54,10 @@ export class ExplorerController
         this.sidebarService = container.resolve(SidebarService);
         this.explorerService = container.resolve(ExplorerService);
         this.folderTreeController = container.resolve(FolderTreeController);
-
-        this.initView();
+        this.builtinService = container.resolve(BuiltinService);
     }
 
-    private initView() {
+    public initView() {
         const explorerEvent = {
             onClick: this.onClick,
             onCollapseChange: this.onCollapseChange,
@@ -74,21 +67,39 @@ export class ExplorerController
 
         const ExplorerView = connect(this.explorerService, Explorer);
 
+        const id = this.builtinService.getConstants().EXPLORER_ACTIVITY_ITEM;
+
+        if (!id) return;
+
         const explorePane = {
-            id: builtInExplorerActivityItem().id,
+            id,
             title: 'EXPLORER',
             render() {
                 return <ExplorerView {...explorerEvent} />;
             },
         };
+        const {
+            builtInExplorerActivityItem,
+            builtInExplorerFolderPanel,
+            builtInExplorerHeaderToolbar,
+        } = this.builtinService.getModules();
 
-        this.activityBarService.add(builtInExplorerActivityItem(), true);
-        this.sidebarService.add(explorePane, true);
-        // add folder panel
-        this.explorerService.addPanel({
-            ...builtInExplorerFolderPanel(),
-            renderPanel: this.renderFolderTree,
-        });
+        if (builtInExplorerActivityItem && builtInExplorerFolderPanel) {
+            this.activityBarService.add(builtInExplorerActivityItem, true);
+            this.sidebarService.add(explorePane, true);
+
+            // add folder panel
+            this.explorerService.addPanel({
+                ...builtInExplorerFolderPanel,
+                renderPanel: this.renderFolderTree,
+            });
+        }
+
+        if (builtInExplorerHeaderToolbar) {
+            this.explorerService.setState({
+                headerToolBar: builtInExplorerHeaderToolbar,
+            });
+        }
     }
 
     public readonly onClick = (
@@ -117,6 +128,15 @@ export class ExplorerController
         parentPanel: IExplorerPanelItem
     ) => {
         const toolbarId = item.id;
+        const {
+            NEW_FILE_COMMAND_ID,
+            NEW_FOLDER_COMMAND_ID,
+            REMOVE_COMMAND_ID,
+            EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
+            EXPLORER_TOGGLE_SAVE_ALL,
+            EXPLORER_TOGGLE_VERTICAL,
+        } = this.builtinService.getConstants();
+
         switch (toolbarId) {
             case NEW_FILE_COMMAND_ID: {
                 this.folderTreeController.createTreeNode?.(FileTypes.File);
@@ -155,6 +175,3 @@ export class ExplorerController
         return <FolderTreeView panel={panel} />;
     };
 }
-
-// Register singleton
-container.resolve(ExplorerController);

--- a/src/controller/explorer/outline.tsx
+++ b/src/controller/explorer/outline.tsx
@@ -2,50 +2,40 @@ import 'reflect-metadata';
 import { Controller } from 'mo/react/controller';
 import { container, singleton } from 'tsyringe';
 import React from 'react';
-import { ExplorerService, IExplorerService } from 'mo/services';
-import { localize } from 'mo/i18n/localize';
+import {
+    BuiltinService,
+    ExplorerService,
+    IBuiltinService,
+    IExplorerService,
+} from 'mo/services';
 
-export interface IOutlineController {}
+export interface IOutlineController {
+    initView(): void;
+}
 
 @singleton()
 export class OutlineController
     extends Controller
     implements IOutlineController {
     private readonly explorerService: IExplorerService;
+    private readonly builtinService: IBuiltinService;
 
     constructor() {
         super();
         this.explorerService = container.resolve(ExplorerService);
-        this.initView();
+        this.builtinService = container.resolve(BuiltinService);
     }
 
-    private initView() {
-        const outlinePanel = {
-            id: 'outline',
-            name: localize('sidebar.explore.outline', 'OUTLINE'),
-            toolbar: [
-                {
-                    id: 'outline-collapse',
-                    title: localize('toolbar.collapseAll', 'Collapse All'),
-                    icon: 'collapse-all',
-                },
-                {
-                    id: 'outline-more',
-                    title: localize(
-                        'sidebar.explore.outlineMore',
-                        'More Actions...'
-                    ),
-                    icon: 'ellipsis',
-                },
-            ],
-        };
-        this.explorerService.addPanel(outlinePanel);
+    public initView() {
+        const {
+            builtInExplorerOutlinePanel,
+        } = this.builtinService.getModules();
+        if (builtInExplorerOutlinePanel) {
+            this.explorerService.addPanel(builtInExplorerOutlinePanel);
+        }
     }
 
     public readonly onClick = (event: React.MouseEvent) => {
         // console.log('onClick:', panelService);
     };
 }
-
-// Register singleton
-container.resolve(OutlineController);

--- a/src/model/workbench/explorer/explorer.tsx
+++ b/src/model/workbench/explorer/explorer.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { IActionBarItemProps } from 'mo/components/actionBar';
-import { NEW_FILE_COMMAND_ID, NEW_FOLDER_COMMAND_ID } from './folderTree';
-import { localize } from 'mo/i18n/localize';
 
 export enum ExplorerEvent {
     onClick = 'explorer.onClick',
@@ -41,146 +39,13 @@ export interface IExplorer {
     headerToolBar: IActionBarItemProps;
 }
 
-export const SAMPLE_FOLDER_PANEL_ID = 'sidebar.explore.folders';
-export const EDITOR_PANEL_ID = 'sidebar.explore.openEditor';
-export const OUTLINE_PANEL_ID = 'sidebar.explore.outline';
-export const OUTLINE_PANEL_MORE_DESC = 'sidebar.explore.outlineMore';
-export const EXPLORER_ACTIVITY_ITEM = 'sidebar.explore.title';
-export const EXPLORER_ACTION_TITLE = 'sidebar.explore.actionDesc';
-export const EXPLORER_TOGGLE_VERTICAL = 'sidebar.explore.toggleVertical';
-export const EXPLORER_TOGGLE_SAVE_ALL = 'sidebar.explore.saveALL';
-export const EXPLORER_TOGGLE_CLOSE_ALL_EDITORS =
-    'sidebar.explore.closeAllEditors';
-export const EXPLORER_TOGGLE_SAVE_GROUP = 'sidebar.explore.saveGroup';
-export const EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS =
-    'sidebar.explore.closeGroupEditors';
-
-export function builtInExplorerActivityItem() {
-    return {
-        id: EXPLORER_ACTIVITY_ITEM,
-        name: localize(EXPLORER_ACTIVITY_ITEM, 'Explore'),
-        icon: 'files',
-        title: localize(EXPLORER_ACTIVITY_ITEM, 'Explore'),
-    };
-}
-
-export function builtInExplorerHeaderToolbar() {
-    return {
-        id: EXPLORER_ACTION_TITLE,
-        title: localize(EXPLORER_ACTION_TITLE, 'View and More Actions...'),
-        icon: 'ellipsis',
-        contextMenu: [],
-    };
-}
-
-export function builtInExplorerEditorPanel() {
-    return {
-        id: EDITOR_PANEL_ID,
-        sortIndex: 9,
-        name: localize(EDITOR_PANEL_ID, 'OPEN EDITORS'),
-        toolbar: [
-            {
-                id: EXPLORER_TOGGLE_VERTICAL,
-                title: localize(EXPLORER_TOGGLE_VERTICAL, 'Toggle Vertical'),
-                icon: 'editor-layout',
-            },
-            {
-                id: EXPLORER_TOGGLE_SAVE_ALL,
-                title: localize(EXPLORER_TOGGLE_SAVE_ALL, 'Save All'),
-                icon: 'save-all',
-            },
-            {
-                id: EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
-                title: localize(
-                    EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
-                    'Close All Editors'
-                ),
-                icon: 'close-all',
-            },
-        ],
-        groupToolbar: [
-            {
-                id: EXPLORER_TOGGLE_SAVE_GROUP,
-                title: localize(EXPLORER_TOGGLE_SAVE_GROUP, 'Save Group'),
-                icon: 'save-all',
-            },
-            {
-                id: EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS,
-                title: localize(
-                    EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS,
-                    'Close Group Editors'
-                ),
-                icon: 'close-all',
-            },
-        ],
-        config: {
-            grow: 0,
-        },
-    };
-}
-
-export function builtInExplorerOutlinePanel() {
-    return {
-        id: OUTLINE_PANEL_ID,
-        name: 'OUTLINE',
-        toolbar: [
-            {
-                id: 'outline-collapse',
-                title: localize('toolbar.collapseAll', 'Collapse All'),
-                icon: 'collapse-all',
-            },
-            {
-                id: OUTLINE_PANEL_MORE_DESC,
-                title: localize(OUTLINE_PANEL_MORE_DESC, 'More Actions...'),
-                icon: 'ellipsis',
-            },
-        ],
-    };
-}
-
-export function builtInExplorerFolderPanel() {
-    return {
-        id: SAMPLE_FOLDER_PANEL_ID,
-        sortIndex: 8,
-        name: localize('menu.defaultProjectName', 'No Open Folder'),
-        toolbar: [
-            {
-                id: NEW_FILE_COMMAND_ID,
-                title: localize('menu.newFile', 'New File'),
-                icon: 'new-file',
-            },
-            {
-                id: NEW_FOLDER_COMMAND_ID,
-                title: localize('menu.newFolder', 'New Folder'),
-                icon: 'new-folder',
-            },
-            {
-                id: 'refresh',
-                title: localize('sidebar.explore.refresh', 'Refresh Explorer'),
-                icon: 'refresh',
-            },
-            {
-                id: 'collapse',
-                title: localize(
-                    'sidebar.explore.collapseFolders',
-                    'Collapse Folders in Explorer'
-                ),
-                icon: 'collapse-all',
-            },
-        ],
-        config: {
-            grow: 2,
-        },
-    };
-}
-
 export class IExplorerModel implements IExplorer {
     public data: IExplorerPanelItem[];
     public headerToolBar: IActionBarItemProps;
 
     constructor(
         data: IExplorerPanelItem[] = [],
-        headerToolBar: IActionBarItemProps = builtInExplorerHeaderToolbar()
+        headerToolBar: IActionBarItemProps = {}
     ) {
         this.data = data;
         this.headerToolBar = headerToolBar;

--- a/src/provider/molecule.tsx
+++ b/src/provider/molecule.tsx
@@ -13,6 +13,14 @@ import {
 import { IMonacoService, MonacoService } from 'mo/monaco/monacoService';
 import { ILocaleService, LocaleService } from 'mo/i18n/localeService';
 import { ILayoutService, LayoutService } from 'mo/services';
+import {
+    EditorTreeController,
+    ExplorerController,
+    IEditorTreeController,
+    IExplorerController,
+    IOutlineController,
+    OutlineController,
+} from 'mo/controller';
 
 export interface IMoleculeProps {
     extensions?: IExtension[];
@@ -35,17 +43,28 @@ export class MoleculeProvider extends Component<IMoleculeProps> {
     private readonly localeService!: ILocaleService;
     private readonly layoutService!: ILayoutService;
 
+    private readonly explorerController: IExplorerController;
+    private readonly editorTreeController: IEditorTreeController;
+    private readonly outlineController: IOutlineController;
+
     constructor(props: IMoleculeProps) {
         super(props);
         this.localeService = container.resolve(LocaleService);
         this.monacoService = container.resolve(MonacoService);
         this.extensionService = container.resolve(ExtensionService);
         this.layoutService = container.resolve(LayoutService);
+
+        this.explorerController = container.resolve(ExplorerController);
+        this.editorTreeController = container.resolve(EditorTreeController);
+        this.outlineController = container.resolve(OutlineController);
         this.preloadLocales();
     }
 
     componentDidMount() {
         this.initialize();
+        this.explorerController.initView();
+        this.editorTreeController.initView();
+        this.outlineController.initView();
     }
 
     preloadLocales() {

--- a/src/services/__tests__/explorerService.test.ts
+++ b/src/services/__tests__/explorerService.test.ts
@@ -1,13 +1,10 @@
-import {
-    builtInExplorerHeaderToolbar,
-    ExplorerEvent,
-    IExplorerPanelItem,
-} from 'mo/model';
+import { ExplorerEvent, IExplorerPanelItem } from 'mo/model';
 import 'reflect-metadata';
 import { expectLoggerErrorToBeCalled } from '@test/utils';
 import { container } from 'tsyringe';
 import { searchById } from 'mo/common/utils';
 import { ExplorerService } from '../workbench';
+import { modules } from '../builtinService/const';
 
 const explorerService = container.resolve(ExplorerService);
 
@@ -38,7 +35,9 @@ describe('Test the Explorer Service', () => {
     test('Should have defualt header bar tool', () => {
         const state = explorerService.getState();
         expect(state.data).toEqual([]);
-        expect(state.headerToolBar).toEqual(builtInExplorerHeaderToolbar());
+        expect(state.headerToolBar).toEqual(
+            modules.builtInExplorerHeaderToolbar
+        );
     });
 
     describe('Test the panel data', () => {

--- a/src/services/builtinService/const.ts
+++ b/src/services/builtinService/const.ts
@@ -1,0 +1,160 @@
+import { localize } from 'mo/i18n/localize';
+import type { IActionBarItemProps } from 'mo/components';
+import type {
+    IActivityBarItem,
+    IEditorOptions,
+    IExplorerPanelItem,
+} from 'mo/model';
+
+export const constants = {
+    PANEL_PROBLEMS: 'panel.problems.title',
+    STATUS_PROBLEMS: 'statusbar.problems.title',
+    SAMPLE_FOLDER_PANEL_ID: 'sidebar.explore.folders',
+    EDITOR_PANEL_ID: 'sidebar.explore.openEditor',
+    OUTLINE_PANEL_ID: 'sidebar.explore.outline',
+    OUTLINE_PANEL_MORE_DESC: 'sidebar.explore.outlineMore',
+    EXPLORER_ACTIVITY_ITEM: 'sidebar.explore.title',
+    EXPLORER_ACTION_TITLE: 'sidebar.explore.actionDesc',
+    EXPLORER_TOGGLE_VERTICAL: 'sidebar.explore.toggleVertical',
+    EXPLORER_TOGGLE_SAVE_ALL: 'sidebar.explore.saveALL',
+    EXPLORER_TOGGLE_CLOSE_ALL_EDITORS: 'sidebar.explore.closeAllEditors',
+    EXPLORER_TOGGLE_SAVE_GROUP: 'sidebar.explore.saveGroup',
+    EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS: 'sidebar.explore.closeGroupEditors',
+    NEW_FILE_COMMAND_ID: 'explorer.newFile',
+    NEW_FOLDER_COMMAND_ID: 'explorer.newFolder',
+    RENAME_COMMAND_ID: 'explorer.rename',
+    REMOVE_COMMAND_ID: 'explorer.remove',
+    DELETE_COMMAND_ID: 'explorer.delete',
+    OPEN_TO_SIDE_COMMAND_ID: 'explorer.openToSide',
+    FIND_IN_WORKSPACE_ID: 'filesExplorer.findInWorkspace',
+    DOWNLOAD_COMMAND_ID: 'explorer.download',
+};
+
+export const modules = {
+    builtInExplorerActivityItem: {
+        id: constants.EXPLORER_ACTIVITY_ITEM,
+        name: localize(constants.EXPLORER_ACTIVITY_ITEM, 'Explore'),
+        icon: 'files',
+        title: localize(constants.EXPLORER_ACTIVITY_ITEM, 'Explore'),
+    } as IActivityBarItem,
+
+    builtInExplorerFolderPanel: {
+        id: constants.SAMPLE_FOLDER_PANEL_ID,
+        sortIndex: 8,
+        name: localize('menu.defaultProjectName', 'No Open Folder'),
+        toolbar: [
+            {
+                id: constants.NEW_FILE_COMMAND_ID,
+                title: localize('menu.newFile', 'New File'),
+                icon: 'new-file',
+            },
+            {
+                id: constants.NEW_FOLDER_COMMAND_ID,
+                title: localize('menu.newFolder', 'New Folder'),
+                icon: 'new-folder',
+            },
+            {
+                id: 'refresh',
+                title: localize('sidebar.explore.refresh', 'Refresh Explorer'),
+                icon: 'refresh',
+            },
+            {
+                id: 'collapse',
+                title: localize(
+                    'sidebar.explore.collapseFolders',
+                    'Collapse Folders in Explorer'
+                ),
+                icon: 'collapse-all',
+            },
+        ],
+        config: {
+            grow: 2,
+        },
+    } as IExplorerPanelItem,
+
+    builtInExplorerHeaderToolbar: {
+        id: constants.EXPLORER_ACTION_TITLE,
+        title: localize(
+            constants.EXPLORER_ACTION_TITLE,
+            'View and More Actions...'
+        ),
+        icon: 'ellipsis',
+        contextMenu: [],
+    } as IActionBarItemProps,
+
+    builtInExplorerEditorPanel: {
+        id: constants.EDITOR_PANEL_ID,
+        sortIndex: 9,
+        name: localize(constants.EDITOR_PANEL_ID, 'OPEN EDITORS'),
+        toolbar: [
+            {
+                id: constants.EXPLORER_TOGGLE_VERTICAL,
+                title: localize(
+                    constants.EXPLORER_TOGGLE_VERTICAL,
+                    'Toggle Vertical'
+                ),
+                icon: 'editor-layout',
+            },
+            {
+                id: constants.EXPLORER_TOGGLE_SAVE_ALL,
+                title: localize(constants.EXPLORER_TOGGLE_SAVE_ALL, 'Save All'),
+                icon: 'save-all',
+            },
+            {
+                id: constants.EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
+                title: localize(
+                    constants.EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
+                    'Close All Editors'
+                ),
+                icon: 'close-all',
+            },
+        ],
+        groupToolbar: [
+            {
+                id: constants.EXPLORER_TOGGLE_SAVE_GROUP,
+                title: localize(
+                    constants.EXPLORER_TOGGLE_SAVE_GROUP,
+                    'Save Group'
+                ),
+                icon: 'save-all',
+            },
+            {
+                id: constants.EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS,
+                title: localize(
+                    constants.EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS,
+                    'Close Group Editors'
+                ),
+                icon: 'close-all',
+            },
+        ],
+        config: {
+            grow: 0,
+        },
+    } as IExplorerPanelItem,
+
+    builtInExplorerOutlinePanel: {
+        id: 'outline',
+        name: localize('sidebar.explore.outline', 'OUTLINE'),
+        toolbar: [
+            {
+                id: 'outline-collapse',
+                title: localize('toolbar.collapseAll', 'Collapse All'),
+                icon: 'collapse-all',
+            },
+            {
+                id: 'outline-more',
+                title: localize(
+                    'sidebar.explore.outlineMore',
+                    'More Actions...'
+                ),
+                icon: 'ellipsis',
+            },
+        ],
+    } as IExplorerPanelItem,
+
+    BuiltInEditorOptions: {
+        renderWhitespace: 'none',
+        tabSize: 4,
+        fontSize: 12,
+    } as IEditorOptions,
+};

--- a/src/services/workbench/explorer/explorerService.ts
+++ b/src/services/workbench/explorer/explorerService.ts
@@ -6,7 +6,6 @@ import {
     IExplorer,
     IExplorerModel,
     ExplorerEvent,
-    builtInExplorerHeaderToolbar,
 } from 'mo/model/workbench/explorer/explorer';
 import cloneDeep from 'lodash/cloneDeep';
 import { IMenuItemProps } from 'mo/components/menu';
@@ -274,7 +273,7 @@ export class ExplorerService
     public reset() {
         this.setState({
             data: [],
-            headerToolBar: builtInExplorerHeaderToolbar(),
+            headerToolBar: {},
         });
     }
 

--- a/src/workbench/sidebar/explore/editorTree.tsx
+++ b/src/workbench/sidebar/explore/editorTree.tsx
@@ -1,11 +1,6 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import { IEditorTreeController } from 'mo/controller';
-import {
-    EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS,
-    EXPLORER_TOGGLE_SAVE_GROUP,
-    IEditor,
-    IEditorGroup,
-} from 'mo/model';
+import { IEditor, IEditorGroup } from 'mo/model';
 import {
     IActionBarItemProps,
     Icon,
@@ -35,9 +30,13 @@ import {
     MAX_GROW_HEIGHT,
 } from 'mo/components/collapse';
 import Scrollbar from 'react-scrollbars-custom';
+import { constants } from 'mo/services/builtinService/const';
 
 // override onContextMenu
-type UnionEditor = Omit<IEditor & IEditorTreeController, 'onContextMenu'>;
+type UnionEditor = Omit<
+    IEditor & IEditorTreeController,
+    'onContextMenu' | 'initView'
+>;
 export interface IOpenEditProps extends UnionEditor {
     /**
      * Group Header toolbar
@@ -163,10 +162,10 @@ const EditorTree = (props: IOpenEditProps) => {
     ) => {
         e.stopPropagation();
         switch (item.id) {
-            case EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS:
+            case constants.EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS:
                 onCloseGroup?.(group.id!);
                 break;
-            case EXPLORER_TOGGLE_SAVE_GROUP:
+            case constants.EXPLORER_TOGGLE_SAVE_GROUP:
                 onSaveGroup?.(group.id!);
                 break;
             default:


### PR DESCRIPTION
### 简介
- explorer 支持内置模块服务

### 主要变更
- 修改 explorer 的默认值，默认值不再通过 model 赋值，而是通过 initView 赋予默认值
- explorerService 和 controller 里面移除了直接 import 内置模块，而是通过 `builtinService` 获取内置模块。如果内置模块被 `inactive` 了，则获取到的是空的
- 改完测试的时候发现一个问题，由于 controller 执行 initView 的时机非常早，无法在该时机之前执行 `molecule.builtin.inactive(xxx)` 导致即使禁用了也无效。于是统一把 `initView` 的方法从 `constructor` 中移除，并在 loadExtensions 之后执行 initView
- 目前来看 constants 应该是不存在需要 inactive 的操作，所以 `inactiveConstant` 的方法暂时标记为*deprecated*