### PR TITLE
fix: initView will override the setDefaultValue

### DIFF
--- a/src/controller/editor.tsx
+++ b/src/controller/editor.tsx
@@ -69,11 +69,17 @@ export class EditorController extends Controller implements IEditorController {
             BuiltInEditorOptions,
         } = this.builtinService.getModules();
 
-        const builtinActions = builtInEditorInitialActions || [];
-        this.editorService.setDefaultActions(builtinActions);
+        const defaultActions = this.editorService.getDefaultActions();
+        if (!defaultActions.length) {
+            const builtinActions = builtInEditorInitialActions || [];
+            this.editorService.setDefaultActions(builtinActions);
+        }
 
-        const builtinMenus = builtInEditorInitialMenu || [];
-        this.editorService.setDefaultMenus(builtinMenus);
+        const defaultMenus = this.editorService.getDefaultMenus();
+        if (!defaultMenus.length) {
+            const builtinMenus = builtInEditorInitialMenu || [];
+            this.editorService.setDefaultMenus(builtinMenus);
+        }
 
         this.editorService.setState({
             editorOptions: BuiltInEditorOptions || {},


### PR DESCRIPTION
### 简介
- 修复无法设置 defaultValue 的问题

### 主要变更
- 在 initView 设置内置默认值之前，先确认 defaultValue 是否存在值，存在则表示用户有自定义值，则不覆盖