### PR TITLE
fix: improve the circular deps error when execute yarn link

### DIFF
--- a/src/workbench/activityBar/index.tsx
+++ b/src/workbench/activityBar/index.tsx
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { connect } from 'mo/react';
-import { ActivityBarController } from 'mo/controller/activityBar';
+import { ActivityBarController } from 'mo/controller';
 
 import ActivityBar from './activityBar';
 import { container } from 'tsyringe';


### PR DESCRIPTION
### 简介
- 修复当 yarn link 到其他项目会报错的情况

### 主要变更
- 是循环依赖导致的
```shell
ReferenceError: Cannot access 'ActivityBarController' before initialization
```