### PR TITLE
WIP: feat: collapse button works in explorer

### DIFF
--- a/src/components/tree/__tests__/__snapshots__/tree.test.tsx.snap
+++ b/src/components/tree/__tests__/__snapshots__/tree.test.tsx.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test the Tree component Match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="mo-tree"
+    draggable="false"
+    role="tree"
+  >
+    <div
+      class="mo-tree__treenode mo-tree__treenode--close"
+      data-id="mo_treeNode_1"
+      data-indent="0"
+      data-key="1"
+      draggable="false"
+      tabindex="0"
+      title="test1"
+    >
+      <div
+        class="mo-tree__indent"
+        style="width: 0px;"
+      />
+      <span
+        class="codicon codicon-chevron-right"
+      />
+      <span
+        class="mo-tree__treenode__title"
+      >
+        test1
+      </span>
+    </div>
+    <div
+      class="mo-tree__treenode mo-tree__treenode--close"
+      data-id="mo_treeNode_2"
+      data-indent="0"
+      data-key="2"
+      draggable="false"
+      tabindex="0"
+      title="test2"
+    >
+      <div
+        class="mo-tree__indent"
+        style="width: 0px;"
+      />
+      <span
+        class="codicon codicon-chevron-right"
+      />
+      <span
+        class="mo-tree__treenode__title"
+      >
+        test2
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/tree/__tests__/tree.test.tsx
+++ b/src/components/tree/__tests__/tree.test.tsx
@@ -37,6 +37,11 @@ jest.mock('lodash', () => {
 describe('Test the Tree component', () => {
     afterEach(cleanup);
 
+    test('Match snapshot', function () {
+        const { asFragment } = render(<TreeView data={mockData} />);
+        expect(asFragment()).toMatchSnapshot();
+    });
+
     test('Should render name', async () => {
         const { getByTitle, findByTitle } = render(
             <TreeView data={mockData} />

--- a/src/components/tree/index.tsx
+++ b/src/components/tree/index.tsx
@@ -56,7 +56,7 @@ export interface ITreeProps {
     className?: string;
     draggable?: boolean;
     expandKeys?: string[];
-    onExpand?: (expandedKeys: React.Key[], node: ITreeNodeItemProps) => void;
+    onExpand?: (expandedKeys: string[], node: ITreeNodeItemProps) => void;
     onSelect?: (node: ITreeNodeItemProps, isUpdate?) => void;
     onTreeClick?: () => void;
     renderTitle?: (
@@ -125,15 +125,14 @@ const TreeView = ({
     };
 
     const handleExpandKey = (key: string, node: ITreeNodeItemProps) => {
-        const index = expandKeys.findIndex((e) => e === key);
+        const expKeys = (controlExpandKeys || expandKeys).concat();
+        const index = expKeys.findIndex((e) => e === key);
         if (index > -1) {
-            expandKeys.splice(index, 1);
+            expKeys.splice(index, 1);
         } else {
-            expandKeys.push(key);
+            expKeys.push(key);
         }
-        onExpand
-            ? onExpand(expandKeys.concat(), node)
-            : setExpandKeys(expandKeys.concat());
+        onExpand ? onExpand(expKeys, node) : setExpandKeys(expKeys);
     };
 
     const handleNodeClick = (

--- a/src/controller/__tests__/explorer.test.ts
+++ b/src/controller/__tests__/explorer.test.ts
@@ -124,7 +124,7 @@ describe('The explorer controller', () => {
         expect(mockFn.mock.calls[0][0]).toBe(mockKeys);
     });
 
-    test('Should support to execute the onToolbarClick method', () => {
+    test('Should support to execute the create tree node in the onToolbarClick method', () => {
         const original = folderTreeController.createTreeNode;
         const mockFn = jest.fn();
         folderTreeController.createTreeNode = mockFn;
@@ -147,7 +147,20 @@ describe('The explorer controller', () => {
         folderTreeController.createTreeNode = original;
     });
 
-    test('Should support to execute the onToolbarClick method', () => {
+    test('Should suppor t o execute the collapse in the onToolbarClick method', () => {
+        const original = folderTreeController.collapseAll;
+        const mockFn = jest.fn();
+        folderTreeController.collapseAll = mockFn;
+
+        const mockItem = { id: constants.COLLAPSE_COMMAND_ID };
+        const mockParentPanel = { id: 'test', name: 'test' };
+        explorerController.onToolbarClick(mockItem, mockParentPanel);
+
+        expect(mockFn).toBeCalled();
+        folderTreeController.createTreeNode = original;
+    });
+
+    test('Should support to execute the others in the onToolbarClick method', () => {
         // REMOVE_COMMAND_ID
         const mockItem = { id: constants.REMOVE_COMMAND_ID };
         const mockParentPanel = { id: 'test', name: 'test' };

--- a/src/controller/__tests__/folderTree.test.ts
+++ b/src/controller/__tests__/folderTree.test.ts
@@ -37,7 +37,18 @@ describe('The folder tree controller', () => {
         reset();
     });
 
-    test('Should support to controll the default value', () => {
+    test('Should support to collapseAll', () => {
+        const mockFn = jest.fn();
+        // @ts-ignore
+        folderTreeController.ref = {
+            clearExpands: mockFn,
+        };
+
+        folderTreeController.collapseAll();
+        expect(mockFn).toBeCalled();
+    });
+
+    test('Should support to control the default value', () => {
         builtinService.inactiveModule('FILE_CONTEXT_MENU');
         builtinService.inactiveModule('BASE_CONTEXT_MENU');
         builtinService.inactiveModule('COMMON_CONTEXT_MENU');

--- a/src/controller/__tests__/folderTree.test.ts
+++ b/src/controller/__tests__/folderTree.test.ts
@@ -39,11 +39,14 @@ describe('The folder tree controller', () => {
 
     test('Should support to collapseAll', () => {
         const mockFn = jest.fn();
-        // @ts-ignore
-        folderTreeController.ref = {
-            clearExpands: mockFn,
-        };
-
+        Object.defineProperty(folderTreeController, 'ref', {
+            value: {
+                current: {
+                    clearExpands: mockFn,
+                },
+            },
+            writable: false,
+        });
         folderTreeController.collapseAll();
         expect(mockFn).toBeCalled();
     });

--- a/src/controller/explorer/explorer.tsx
+++ b/src/controller/explorer/explorer.tsx
@@ -130,6 +130,7 @@ export class ExplorerController
             NEW_FILE_COMMAND_ID,
             NEW_FOLDER_COMMAND_ID,
             REMOVE_COMMAND_ID,
+            COLLAPSE_COMMAND_ID,
             EXPLORER_TOGGLE_CLOSE_ALL_EDITORS,
             EXPLORER_TOGGLE_SAVE_ALL,
             EXPLORER_TOGGLE_VERTICAL,
@@ -146,6 +147,10 @@ export class ExplorerController
             }
             case REMOVE_COMMAND_ID: {
                 this.emit(ExplorerEvent.onRemovePanel, parentPanel);
+                break;
+            }
+            case COLLAPSE_COMMAND_ID: {
+                this.folderTreeController.collapseAll?.();
                 break;
             }
             case EXPLORER_TOGGLE_CLOSE_ALL_EDITORS: {

--- a/src/controller/explorer/folderTree.tsx
+++ b/src/controller/explorer/folderTree.tsx
@@ -19,6 +19,7 @@ import type { UniqueId } from 'mo/common/types';
 
 export interface IFolderTreeController extends Partial<Controller> {
     readonly createTreeNode?: (type: FileType, id?: UniqueId) => void;
+    readonly collapseAll?: () => void;
     readonly onClickContextMenu?: (
         contextMenu: IMenuItemProps,
         treeNode?: IFolderTreeNodeProps
@@ -39,6 +40,7 @@ export interface IFolderTreeController extends Partial<Controller> {
 export class FolderTreeController
     extends Controller
     implements IFolderTreeController {
+    public readonly ref: any;
     private readonly folderTreeService: IFolderTreeService;
     private readonly builtinService: IBuiltinService;
 
@@ -114,6 +116,12 @@ export class FolderTreeController
             this.emit(FolderTreeEvent.onCreate, type, nodeId);
         } else {
             this.emit(FolderTreeEvent.onCreate, type, id);
+        }
+    };
+
+    public collapseAll = () => {
+        if (this.ref.current) {
+            this.ref.current.clearExpands();
         }
     };
 

--- a/src/react/__tests__/connector.test.tsx
+++ b/src/react/__tests__/connector.test.tsx
@@ -85,19 +85,18 @@ describe('Test Connector Component', () => {
 
     test('Should bind refs into controller', () => {
         const withRef = new TestControllerA();
+        const refObj = {
+            test: jest.fn(),
+        };
         const RefComponent = forwardRef((props, ref) => {
-            useImperativeHandle(ref, () => ({
-                test: jest.fn(),
-            }));
+            useImperativeHandle(ref, () => refObj);
             return <div>test</div>;
         });
         const TestView = connect(serviceA, RefComponent, withRef);
         render(<TestView />);
 
         // @ts-ignore
-        expect(withRef.ref.current).toEqual({
-            test: jest.fn(),
-        });
+        expect(withRef.ref.current).toBe(refObj);
     });
 
     test('Test connect update to the Component view after state changed.', () => {

--- a/src/react/__tests__/connector.test.tsx
+++ b/src/react/__tests__/connector.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, useImperativeHandle } from 'react';
 import { Component, connect } from 'mo/react';
 import { fireEvent, render } from '@testing-library/react';
 
@@ -81,6 +81,23 @@ describe('Test Connector Component', () => {
         );
         expect(getByText('A')).not.toBeNull();
         expect(getByText('B')).not.toBeNull();
+    });
+
+    test('Should bind refs into controller', () => {
+        const withRef = new TestControllerA();
+        const RefComponent = forwardRef((props, ref) => {
+            useImperativeHandle(ref, () => ({
+                test: jest.fn(),
+            }));
+            return <div>test</div>;
+        });
+        const TestView = connect(serviceA, RefComponent, withRef);
+        render(<TestView />);
+
+        // @ts-ignore
+        expect(withRef.ref.current).toEqual({
+            test: jest.fn(),
+        });
     });
 
     test('Test connect update to the Component view after state changed.', () => {

--- a/src/react/connector.tsx
+++ b/src/react/connector.tsx
@@ -21,16 +21,22 @@ export function connect<T = any>(
     return class Connector extends Component<T, any> {
         state: { lastUpdated: number };
         private _isMounted = false;
+        private viewRef: React.RefObject<any>;
         constructor(props) {
             super(props);
             this.onChange = this.onChange.bind(this);
             this.state = {
                 lastUpdated: Date.now(),
             };
+            this.viewRef = React.createRef<any>();
         }
 
         componentDidMount() {
             this._isMounted = true;
+            if (this.viewRef && Controller) {
+                // @ts-ignore
+                Controller.ref = this.viewRef;
+            }
             this.handleService((service) => {
                 service.onUpdateState(this.onChange);
             });
@@ -94,6 +100,7 @@ export function connect<T = any>(
         render() {
             return (
                 <View
+                    ref={this.viewRef}
                     {...this.state}
                     {...this.getServiceState()}
                     {...this.props}

--- a/src/services/builtinService/const.ts
+++ b/src/services/builtinService/const.ts
@@ -29,6 +29,7 @@ export const constants = {
     EXPLORER_TOGGLE_CLOSE_GROUP_EDITORS: 'sidebar.explore.closeGroupEditors',
     NEW_FILE_COMMAND_ID: 'explorer.newFile',
     NEW_FOLDER_COMMAND_ID: 'explorer.newFolder',
+    COLLAPSE_COMMAND_ID: 'explore.collapse',
     RENAME_COMMAND_ID: 'explorer.rename',
     REMOVE_COMMAND_ID: 'explorer.remove',
     DELETE_COMMAND_ID: 'explorer.delete',
@@ -123,7 +124,7 @@ export const modules = {
                     icon: 'refresh',
                 },
                 {
-                    id: 'collapse',
+                    id: constants.COLLAPSE_COMMAND_ID,
                     title: localize(
                         'sidebar.explore.collapseFolders',
                         'Collapse Folders in Explorer'

--- a/src/workbench/sidebar/__tests__/__snapshots__/folderTree.test.tsx.snap
+++ b/src/workbench/sidebar/__tests__/__snapshots__/folderTree.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The FolderTree Component Match Snapshot 1`] = `
+<DocumentFragment>
+  <div
+    data-content="test"
+    style="height: 100%;"
+  >
+    <div
+      class="mo-tree mo-folderTree"
+      draggable="true"
+      role="tree"
+    >
+      <div
+        class="mo-tree__treenode mo-tree__treenode--close"
+        data-id="mo_treeNode_test"
+        data-indent="0"
+        data-key="test"
+        draggable="true"
+        tabindex="0"
+        title="test"
+      >
+        <div
+          class="mo-tree__indent"
+          style="width: 0px;"
+        />
+        <span
+          class="codicon codicon-chevron-right"
+        />
+        <span
+          class="mo-tree__treenode__title"
+        >
+          test
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/workbench/sidebar/explore/folderTree.tsx
+++ b/src/workbench/sidebar/explore/folderTree.tsx
@@ -1,5 +1,13 @@
 import 'reflect-metadata';
-import React, { memo, useRef, useEffect, useLayoutEffect } from 'react';
+import React, {
+    memo,
+    useRef,
+    useEffect,
+    useLayoutEffect,
+    forwardRef,
+    useImperativeHandle,
+    useState,
+} from 'react';
 import { IFolderTree, IFolderTreeNodeProps } from 'mo/model';
 import { select, getEventPosition } from 'mo/common/dom';
 import Tree from 'mo/components/tree';
@@ -19,6 +27,10 @@ import { ICollapseItem } from 'mo/components/collapse';
 
 export interface IFolderTreeProps extends IFolderTreeController, IFolderTree {
     panel: ICollapseItem;
+}
+
+export interface IFolderTreeRef {
+    clearExpands: () => void;
 }
 
 const detectHasEditableStatus = (data) => {
@@ -66,183 +78,203 @@ const Input = React.forwardRef(
     }
 );
 
-const FolderTree: React.FunctionComponent<IFolderTreeProps> = (props) => {
-    const {
-        folderTree = {},
-        entry,
-        panel,
-        onUpdateFileName,
-        onSelectFile,
-        onDropTree,
-        onClickContextMenu,
-        onRightClick,
-        onLoadData,
-        createTreeNode,
-        ...restProps
-    } = props;
+const FolderTree = forwardRef<IFolderTreeRef, IFolderTreeProps>(
+    (props, ref) => {
+        const {
+            folderTree = {},
+            entry,
+            panel,
+            onUpdateFileName,
+            onSelectFile,
+            onDropTree,
+            onClickContextMenu,
+            onRightClick,
+            onLoadData,
+            createTreeNode,
+            ...restProps
+        } = props;
 
-    const { data = [], folderPanelContextMenu = [] } = folderTree;
+        const { data = [], folderPanelContextMenu = [] } = folderTree;
+        const [expands, setExpands] = useState<string[]>([]);
 
-    const handleAddRootFolder = () => {
-        createTreeNode?.('RootFolder');
-    };
-
-    const welcomePage = (
-        <div data-content={panel.id}>
-            {entry ? (
-                <>{entry}</>
-            ) : (
-                <div style={{ padding: '10px 5px' }}>
-                    you have not yet opened a folder
-                    <Button onClick={handleAddRootFolder}>Add Folder</Button>
-                </div>
-            )}
-        </div>
-    );
-
-    if (!data.length) return welcomePage;
-
-    const inputRef = useRef<HTMLInputElement>(null);
-    // tree context view
-    const contextMenu = useRef<ReturnType<typeof useContextMenu>>();
-
-    // panel context view
-    const contextView = useContextView();
-
-    // to detect current tree whether is editable
-    const hasEditable = detectHasEditableStatus(data);
-
-    const onClickMenuItem = (e, item) => {
-        onClickContextMenu?.(item);
-        contextMenu.current?.hide();
-    };
-
-    // init context menu
-    const initContextMenu = () => {
-        return useContextMenu({
-            anchor: select(`.${folderTreeClassName}`),
-            render: () => (
-                <Menu
-                    role="menu"
-                    onClick={onClickMenuItem}
-                    data={folderPanelContextMenu}
-                />
-            ),
-        });
-    };
-
-    const handleMenuClick = (
-        item: IMenuItemProps,
-        data: IFolderTreeNodeProps
-    ) => {
-        onClickContextMenu?.(item, data);
-        contextView.hide();
-    };
-
-    const handleRightClick = (event, data) => {
-        const menuItems = onRightClick?.(data) || [];
-
-        menuItems.length &&
-            contextView?.show(getEventPosition(event), () => (
-                <Menu
-                    role="menu"
-                    onClick={(_, item) => handleMenuClick(item!, data)}
-                    data={menuItems}
-                />
-            ));
-    };
-
-    const handleUpdateFile = (
-        e: HTMLInputElement,
-        node: IFolderTreeNodeProps
-    ) => {
-        const newName = e.value;
-        onUpdateFileName?.({
-            ...node,
-            name: newName,
-        });
-    };
-
-    /**
-     * update file info when input blur
-     */
-    const handleInputBlur = (
-        e: React.FocusEvent<HTMLInputElement>,
-        node: IFolderTreeNodeProps
-    ) => {
-        handleUpdateFile(e.target, node);
-    };
-
-    /**
-     * update file info when press `Enter` or `esc`
-     */
-    const handleInputKeyDown = (
-        e: React.KeyboardEvent<HTMLInputElement>,
-        node: IFolderTreeNodeProps
-    ) => {
-        if (e.keyCode === 13 || e.keyCode === 27) {
-            handleUpdateFile(e.target as EventTarget & HTMLInputElement, node);
-        }
-    };
-
-    const renderTitle = (node: IFolderTreeNodeProps) => {
-        const { isEditable, name } = node;
-
-        return isEditable ? (
-            <Input
-                role="input"
-                className={folderTreeInputClassName}
-                type="text"
-                defaultValue={name}
-                ref={inputRef}
-                onKeyDown={(e) => handleInputKeyDown(e, node)}
-                autoComplete="off"
-                autoFocus
-                onBlur={(e) => handleInputBlur(e, node)}
-            />
-        ) : (
-            name!
-        );
-    };
-
-    const handleTreeClick = () => {
-        onSelectFile?.();
-    };
-
-    const handleDropTree = (source, target) => {
-        onDropTree?.(source, target);
-    };
-
-    useEffect(() => {
-        if (folderPanelContextMenu.length > 0) {
-            contextMenu.current = initContextMenu();
-        }
-        return () => {
-            contextMenu.current?.dispose();
+        const handleAddRootFolder = () => {
+            createTreeNode?.('RootFolder');
         };
-    }, [data.length]);
 
-    return (
-        <Scrollable noScrollX isShowShadow>
-            <div data-content={panel.id} style={{ height: '100%' }}>
-                <Tree
-                    // root folder do not render
-                    data={data[0]?.children || []}
-                    className={classNames(
-                        folderTreeClassName,
-                        hasEditable && folderTreeEditClassName
-                    )}
-                    draggable={!hasEditable}
-                    onDropTree={handleDropTree}
-                    onSelect={onSelectFile}
-                    onTreeClick={handleTreeClick}
-                    onRightClick={handleRightClick}
-                    renderTitle={renderTitle}
-                    onLoadData={onLoadData}
-                    {...restProps}
-                />
+        useImperativeHandle(ref, () => ({
+            clearExpands: () => {
+                setExpands([]);
+            },
+        }));
+
+        const welcomePage = (
+            <div data-content={panel.id}>
+                {entry ? (
+                    <>{entry}</>
+                ) : (
+                    <div style={{ padding: '10px 5px' }}>
+                        you have not yet opened a folder
+                        <Button onClick={handleAddRootFolder}>
+                            Add Folder
+                        </Button>
+                    </div>
+                )}
             </div>
-        </Scrollable>
-    );
-};
+        );
+
+        const inputRef = useRef<HTMLInputElement>(null);
+        // tree context view
+        const contextMenu = useRef<ReturnType<typeof useContextMenu>>();
+
+        // panel context view
+        const contextView = useContextView();
+
+        // to detect current tree whether is editable
+        const hasEditable = detectHasEditableStatus(data);
+
+        const onClickMenuItem = (e, item) => {
+            onClickContextMenu?.(item);
+            contextMenu.current?.hide();
+        };
+
+        // init context menu
+        const initContextMenu = () => {
+            return useContextMenu({
+                anchor: select(`.${folderTreeClassName}`),
+                render: () => (
+                    <Menu
+                        role="menu"
+                        onClick={onClickMenuItem}
+                        data={folderPanelContextMenu}
+                    />
+                ),
+            });
+        };
+
+        const handleExpandKeys = (keys: string[]) => {
+            setExpands(keys);
+        };
+
+        const handleMenuClick = (
+            item: IMenuItemProps,
+            data: IFolderTreeNodeProps
+        ) => {
+            onClickContextMenu?.(item, data);
+            contextView.hide();
+        };
+
+        const handleRightClick = (event, data) => {
+            const menuItems = onRightClick?.(data) || [];
+
+            menuItems.length &&
+                contextView?.show(getEventPosition(event), () => (
+                    <Menu
+                        role="menu"
+                        onClick={(_, item) => handleMenuClick(item!, data)}
+                        data={menuItems}
+                    />
+                ));
+        };
+
+        const handleUpdateFile = (
+            e: HTMLInputElement,
+            node: IFolderTreeNodeProps
+        ) => {
+            const newName = e.value;
+            onUpdateFileName?.({
+                ...node,
+                name: newName,
+            });
+        };
+
+        /**
+         * update file info when input blur
+         */
+        const handleInputBlur = (
+            e: React.FocusEvent<HTMLInputElement>,
+            node: IFolderTreeNodeProps
+        ) => {
+            handleUpdateFile(e.target, node);
+        };
+
+        /**
+         * update file info when press `Enter` or `esc`
+         */
+        const handleInputKeyDown = (
+            e: React.KeyboardEvent<HTMLInputElement>,
+            node: IFolderTreeNodeProps
+        ) => {
+            if (e.keyCode === 13 || e.keyCode === 27) {
+                handleUpdateFile(
+                    e.target as EventTarget & HTMLInputElement,
+                    node
+                );
+            }
+        };
+
+        const renderTitle = (node: IFolderTreeNodeProps) => {
+            const { isEditable, name } = node;
+
+            return isEditable ? (
+                <Input
+                    role="input"
+                    className={folderTreeInputClassName}
+                    type="text"
+                    defaultValue={name}
+                    ref={inputRef}
+                    onKeyDown={(e) => handleInputKeyDown(e, node)}
+                    autoComplete="off"
+                    autoFocus
+                    onBlur={(e) => handleInputBlur(e, node)}
+                />
+            ) : (
+                name!
+            );
+        };
+
+        const handleTreeClick = () => {
+            onSelectFile?.();
+        };
+
+        const handleDropTree = (source, target) => {
+            onDropTree?.(source, target);
+        };
+
+        useEffect(() => {
+            if (folderPanelContextMenu.length > 0) {
+                contextMenu.current = initContextMenu();
+            }
+            return () => {
+                contextMenu.current?.dispose();
+            };
+        }, [data.length]);
+
+        if (!data.length) return welcomePage;
+
+        return (
+            <Scrollable noScrollX isShowShadow>
+                <div data-content={panel.id} style={{ height: '100%' }}>
+                    <Tree
+                        // root folder do not render
+                        data={data[0]?.children || []}
+                        className={classNames(
+                            folderTreeClassName,
+                            hasEditable && folderTreeEditClassName
+                        )}
+                        expandKeys={expands}
+                        onExpand={handleExpandKeys}
+                        draggable={!hasEditable}
+                        onDropTree={handleDropTree}
+                        onSelect={onSelectFile}
+                        onTreeClick={handleTreeClick}
+                        onRightClick={handleRightClick}
+                        renderTitle={renderTitle}
+                        onLoadData={onLoadData}
+                        {...restProps}
+                    />
+                </div>
+            </Scrollable>
+        );
+    }
+);
 export default memo(FolderTree);


### PR DESCRIPTION
## 简介
- Explorer 窗口的 collapse 按钮支持点击

## 主要变更
- ExplorerController 支持 collapse 按钮的点击事件
- 点击事件调用 FolderTreeController 相关事件
- FolderTreeController 会调用 ref 中的相关事件方法（ref 通过 connect 函数，将组件的 ref 值挂载到 Controller 上）

## Related PRs
由于 Tree 组件经过重构后，老 PR 内容无法适应 Closed #432 