### PR TITLE
feat: provide types of Keybinding and QuickAccess

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -5,3 +5,4 @@ export * from './settings';
 export * from './notification';
 export * from './problems';
 export * from './colorTheme';
+export * from './keybinding';

--- a/src/molecule.api.ts
+++ b/src/molecule.api.ts
@@ -4,6 +4,8 @@ import { container } from 'tsyringe';
 export * as event from 'mo/common/event';
 export * as react from 'mo/react';
 export * as component from 'mo/components';
+export * as monaco from 'mo/monaco/api';
+
 export * from 'mo/i18n';
 export * from 'mo/workbench';
 export * from 'mo/services';

--- a/src/monaco/api.ts
+++ b/src/monaco/api.ts
@@ -1,0 +1,3 @@
+export { KeyChord } from 'monaco-editor/esm/vs/base/common/keyCodes';
+export type { IQuickInputService } from 'monaco-editor/esm/vs/platform/quickinput/common/quickInput';
+export { KeybindingWeight, Action2 } from './common';

--- a/src/monaco/index.ts
+++ b/src/monaco/index.ts
@@ -22,3 +22,5 @@ import 'monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standalon
 import 'monaco-editor/esm/vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast';
 
 export * from 'monaco-editor/esm/vs/editor/editor.api.js';
+
+export { KeybindingWeight, Action2 } from './common';

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -60,6 +60,7 @@ module.exports = {
                 'api/namespaces/molecule.model',
                 'api/namespaces/molecule.react',
                 'api/namespaces/molecule.event',
+                'api/namespaces/molecule.monaco',
             ],
         },
         {


### PR DESCRIPTION
## Description

导出 Keybinding， QuickAccess 相关类型文件

Fixes #532 

## Changes

-  导出 `monaco`/common 中的相关文件
- 导出 `KeyChord, IQuickAccessService`
- 导出 **keybinding** `model` 相关类型声明
