### PR TITLE
fix: not allowed to reload the initialize method 

### DIFF
--- a/src/provider/__tests__/molecule.test.tsx
+++ b/src/provider/__tests__/molecule.test.tsx
@@ -4,11 +4,16 @@ import '@testing-library/jest-dom';
 import renderer from 'react-test-renderer';
 
 import { select } from 'mo/common/dom';
-import { MoleculeProvider, Workbench } from 'mo';
+import molecule, { MoleculeProvider, Workbench } from 'mo';
 
 import { customExtensions } from '../../../stories/extensions';
 
 describe('Test MoleculeProvider', () => {
+    beforeEach(() => {
+        // Reset the extensions loaded state
+        molecule.extension.setLoaded(false);
+    });
+
     test('Match The MoleculeProvider snapshot', () => {
         const component = renderer.create(
             <MoleculeProvider>
@@ -36,13 +41,13 @@ describe('Test MoleculeProvider', () => {
         ).toBeInTheDocument();
     });
 
-    test('MoleculeProvider load the extensions', () => {
+    test('MoleculeProvider load the extensions', async () => {
         render(
             <MoleculeProvider extensions={customExtensions}>
                 <Workbench />
             </MoleculeProvider>
         );
-        expect(
+        await expect(
             select('div[data-id="ActivityBarTestPane"]')
         ).toBeInTheDocument();
     });

--- a/src/provider/molecule.tsx
+++ b/src/provider/molecule.tsx
@@ -48,7 +48,9 @@ export class MoleculeProvider extends Component<IMoleculeProps> {
     }
 
     componentDidMount() {
-        this.initialize();
+        if (!this.extensionService.isLoaded()) {
+            this.initialize();
+        }
     }
 
     initialize() {
@@ -73,6 +75,9 @@ export class MoleculeProvider extends Component<IMoleculeProps> {
 
         // Finally, handle the rest of extensions
         this.extensionService.load(restExts);
+
+        // Mark the extensionService as loaded
+        this.extensionService.setLoaded();
     }
 
     initLocaleExts(languages: IExtension[]) {

--- a/src/services/__tests__/extensionService.test.ts
+++ b/src/services/__tests__/extensionService.test.ts
@@ -181,4 +181,12 @@ describe('Test ExtensionService', () => {
         expect(languagesExts.length).toBe(1);
         expect(otherExts.length).toBe(1);
     });
+
+    test('The ExtensionService loaded status', () => {
+        expect(instance.isLoaded()).not.toBeTruthy();
+        instance.setLoaded();
+        expect(instance.isLoaded()).toBeTruthy();
+        instance.setLoaded(false);
+        expect(instance.isLoaded()).not.toBeTruthy();
+    });
 });

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -96,6 +96,14 @@ export interface IExtensionService {
      * @returns [ languagesExts, otherExtensions ]
      */
     splitLanguagesExts(extensions: IExtension[]): [IExtension[], IExtension[]];
+    /**
+     * whether the extensions are loaded
+     */
+    isLoaded(): boolean;
+    /**
+     * Set the extensions are loaded
+     */
+    setLoaded(flag?: boolean): void;
 }
 
 @singleton()
@@ -105,11 +113,24 @@ export class ExtensionService implements IExtensionService {
     private readonly monacoService: IMonacoService;
     private _inactive: Function | undefined;
     private readonly localeService: ILocaleService;
+    /**
+     * TODO: This property is used for marking the extensions were loaded
+     * we are going to refactor this logic after redesign the Molecule lifecycle.
+     */
+    private _isLoaded: boolean = false;
 
     constructor() {
         this.colorThemeService = container.resolve(ColorThemeService);
         this.monacoService = container.resolve(MonacoService);
         this.localeService = container.resolve(LocaleService);
+    }
+
+    public setLoaded(flag?: boolean): void {
+        this._isLoaded = flag !== undefined ? flag : true;
+    }
+
+    public isLoaded(): boolean {
+        return this._isLoaded;
     }
 
     public getExtension(id: UniqueId): IExtension | undefined {


### PR DESCRIPTION
## Description

Disable to reload the `initialize` method of `MoleculeProvider` when triggering the Componen hot reload.

Fixes #579 

## Changes

-   Add `loaded` flag in `ExtensionService`
-   Not allowed to load the `initialize` if the `ExtensionService` is loaded
-  Add unit tests for **loaded** logic
