### PR TITLE
docs: translate Overview, QuickStart to English

### DIFF
--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -56,7 +56,7 @@ For more information on how to **customize quick access**, please refer to [Exte
 
 ## Components
 
-Molecule provides many basic React UI Atomic Components such as [Menu][menu-url],[TreeView][treeview-url],[ContextMenu][ctxmenu-url],etc. At the same time, our Workbench UI is built on the basis of these components. Through these built-in components, we can meet the extension demands of out developers on UI to a greater extend. In addition, Molecule also supports the use of third-party UI component libraries like [antd](http://ant.design/), to meet its own custom requirements.
+Molecule provides many basic React UI [Atomic Components](./api/namespaces/molecule.component) such as [Menu][menu-url],[TreeView][treeview-url],[ContextMenu][ctxmenu-url],etc. At the same time, our Workbench UI is built on the basis of these components. Through these built-in components, we can meet the extension demands of out developers on UI to a greater extend. In addition, Molecule also supports the use of third-party UI component libraries like [antd](http://ant.design/), to meet its own custom requirements.
 
 Currently, we use Storybook to develop and maintain these components. Regarding the use of these components, we can find examples in [stories](https://github.com/DTStack/molecule/tree/main/stories) under the source code repository.
 

--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -32,7 +32,7 @@ For more details about the **customized** locale, please refer to [Extended Lang
 
 ## Settings
 
-Molecule supports modifying some configuration items in [Settings] (./guides/extend-settings). When you want to modify the size of the **font** in the **editor**, you only need to open the '**Settings**' option in the settings menu, and then change the value of `editor.fontSize` from **12** amended to **14**.
+Molecule supports modifying some configuration items in [Settings](./guides/extend-settings). When you want to modify the size of the **font** in the **editor**, you only need to open the '**Settings**' option in the settings menu, and then change the value of `editor.fontSize` from **12** amended to **14**.
 
 For more details about the **Extended settings**, please refer to [Extended settings](./guides/extend-settings).
 

--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -15,7 +15,7 @@ Before Molecule is for official use, let's learn some **fundamentals** about it,
 
 [Workbench](./guides/extend-workbench)
 is the most important part in IDE UI. It contains many components，which includes 6 main modules named **MenuBar**, **ActivityBar**, **Sidebar**, **Editor**, **Panel**, and **StatusBar** in Molecule.
-Every core module improves both React Components and basic Service Object in order to make more easier to use or to hook for producers.
+Each core module provides a **React component** and a basic **Service object** for developers to operate or customize.
 
 ## ColorTheme
 
@@ -32,7 +32,7 @@ For more details about the **customized** locale, please refer to [Extended Lang
 
 ## Settings
 
-Molecule supports modifying some configuration items in [Settings](./guides/extend-settings). When you want to modify the size of the **font** in the **editor**, you only need to open the '**Settings**' option in the settings menu, and then change the value of `editor.fontSize` from **12** amended to **14**.
+Molecule supports modifying some configuration items in [Settings](./guides/extend-settings). When you want to modify the size of the **font** in the **editor**, you only need to open the '**Settings**' option in the settings menu, and then change the value of `editor.fontSize` from **12** to **14**.
 
 For more details about the **Extended settings**, please refer to [Extended settings](./guides/extend-settings).
 

--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -3,60 +3,62 @@ title: Overview
 sidebar_label: Overview
 ---
 
-在正式开始使用 Molecule 前，我们一起来简单的了解下几个基本的**概念**，以确保您能[快速开始](./quick-start.md) Molecule 的使用。
+Before Molecule is for official use, let's learn some **fundamentals** about it, to make sure that you can have a [quick start](./quick-start.md) of Molecule.
 
 ![molecule](/img/molecule.png)
 
-## 扩展（Extension）
+## Extension
 
-[扩展（Extension）](./guides/extension)是 Molecule 用来实现**功能自定义**的**插件技术**。通过扩展机制，我们可以轻松实现自定义扩展 **Workbench、 ColorTheme、i18n、Settings、Keybinding、QuickAccess** 等核心功能。
+[Extension](./guides/extension)is a **plug-in technology** used by Molecule to realize **function customization**. With the extension, it's easy to extend core functionalities such as **Workbench, ColorTheme, i18n, Settings,Keybinding, QuickAccess**.
 
-## 工作台（Workbench）
+## Workbench
 
-[工作台（Workbench）](./guides/extend-workbench)是 IDE UI 中最重要的部分了。在 Molecule 中我们把工作台抽象成了多个子组件：**MenuBar**、 **ActivityBar**、**Sidebar**、 **Editor**、**Panel**、**StatusBar** 主要 6 大模块。每个核心模块又分别提供了 **React 组件**和基础的**服务（Service）对象**，以便开发者进行操作或者自定义。
+[Workbench](./guides/extend-workbench)
+is the most important part in IDE UI. It contains many components，which includes 6 main modules named **MenuBar**, **ActivityBar**, **Sidebar**, **Editor**, **Panel**, and **StatusBar** in Molecule.
+Every core module improves both React Components and basic Service Object in order to make more easier to use or to hook for producers.
 
-## 颜色主题（ColorTheme）
+## ColorTheme
 
-Molecule 兼容了 [VSCode ColorTheme](https://code.visualstudio.com/api/references/theme-color) ，并实现了一套简单**扩展**机制。通过快捷键 `Command/Ctrl + K` 即可打开主题「**切换面板**」，或者通过「**设置菜单**」，在菜单的最下面看到「**颜色主题**」。
+Molecule is compatible with [VSCode ColorTheme](https://code.visualstudio.com/api/references/theme-color), and implement a set of extension mechanisms. Use the shortcut combination `Command/Ctrl + K` to open the theme '**switch panel**', or through the '**settings menu**', you can see the '**ColorTheme**' at the bottom of the menu.
 
-在 Molecule 中我们有许多内置的主题，包括 `Dark`、 `Light`、`Monakai`、`Github Plus`、`High Contrast` 等等。
+There are kinds of built-in themes in Molecule ,including `Dark`, `Light`, `Monakai`, `Github Plus`, `High Contrast`,etc.
 
-## 国际化（i18n）
+## i18n
 
-Molecule 有一个基本的[国际化（i18n）](./guides/extend-locales)方案，并支持扩展（Extension）机制。默认有两种内置的语言，分别是**中文**和**英文**。
-我们可以通过快捷键 `Command/Ctrl Shift + L` 打开语言「**切换面板**」，选择一种语言，然后确认选择，然后在页面的**右下角**将会有一个提醒窗口，点击确认会重新加载当前页面，之后语言环境就会发生更改。
+Molecule has a basic [Internationalization (i18n)](./guides/extend-locales) program and supports the extension mechanism. There are two built-in languages ​​by default, **Chinese** and **English**.
+We can use the shortcut combination `Command/Ctrl Shift + L` to open the language 「**switch panel**」, select a language, and then confirm the selection, and then there will be a reminder window in the **bottom right corner** of the page. Clicking to confirm will reload the current page, and then the locale will be changed.
 
-更多关于**自定义**语言环境的细节，请参考[扩展语言环境](./guides/extend-locales)。
+For more details about the **customized** locale, please refer to [Extended Language Environment](./guides/extend-locales).
 
-## 设置（Settings）
+## Settings
 
-Molecule 支持通过在[设置（Settings）](./guides/extend-settings)中修改部分配置项。例如：当你想要修改**编辑器**的**字体**大小时，只需要打开设置菜单中的「**设置**」选项，然后把 `editor.fontSize` 的值从 **12** 修改至 **14** 即可。
+Molecule supports modifying some configuration items in [Settings] (./guides/extend-settings). When you want to modify the size of the **font** in the **editor**, you only need to open the '**Settings**' option in the settings menu, and then change the value of `editor.fontSize` from **12** amended to **14**.
 
-更多关于去**扩展设置项**的内容，请参考 [扩展设置](./guides/extend-settings) 。
+For more details about the **Extended settings**, please refer to [Extended settings](./guides/extend-settings).
 
-## 快捷键（Keybinding）
+## Keybinding
 
-Molecule 利用 monaco-editor 强大的 Keybinding 服务，支持以扩展的方式自定义各种[快捷键（Keybinding）](./guides/extend-keybinding)。Molecule 默认也有一些内置的快捷键：
+Molecule utilizes the powerful Keybinding service of monaco-editor to support customizing various [Keybinding](./guides/extend-keybinding) in an extended manner. Molecule also has some built-in shortcut keys by default:
 
--   `Command/Ctrl + ,` 可以快速访问设置；
--   `Command/Ctrl + Shift + L` 可以快速切换**语言环境**；
--   `Command/Ctrl + Shift + P` 可以快速访问**Command Palette**；
+-   `Command/Ctrl + ,` can quickly access settings;
+-   `Command/Ctrl + Shift + L` can quickly switch **locale**;
+-   `Command/Ctrl + Shift + P` can quickly access **Command Palette**;
 
-关于如何**自定义快捷键**，请参考[扩展快捷键](./guides/extend-keybinding)。
+For how to **Customize Keybinding**, please refer to [Extended Shortcut Keys](./guides/extend-keybinding).
 
-## 快捷访问（QuickAccess）
+## QuickAccess
 
 ![QuickAccess](/img/guides/quick-access.jpg)
 
-[快捷访问（QuickAccess）](./guides/extend-quick-access)是 **VSCode、Sublime** 等编辑器工具中场景的一种交互组件。我们基于 monaco-editor 内置的 `QuickInputService` 和 Molecule 的扩展机制，让开发者可以轻松的实现自己的快捷访问。
+[QuickAccess](./guides/extend-quick-access) is an interactive component of scenes in editor tools such as **VSCode and Sublime**. We are based on the built-in `QuickInputService` of monaco-editor and Molecule's extension mechanism, allowing developers to easily implement their own quick access.
 
-更多关于如何**自定义快捷访问**的内容，请参考[扩展快速访问](./guides/extend-quick-access)来了解如何扩展快速访问面板。
+For more information on how to **customize quick access**, please refer to [Extended Quick Access](./guides/extend-quick-access) to learn how to extend the quick access panel.
 
-## 原子组件（Components)
+## Components
 
-Molecule 提供了很多基本的 React UI [原子组件](./api/namespaces/molecule.component)，例如 [Menu][menu-url]、[TreeView][treeview-url][、ContextMenu][ctxmenu-url] 等等。而我们的 Workbench UI 就是在这些组件的基础上构建而来。通过这些内置的组件，我们可以在更大程度上，满足我们开发者在 UI 上的扩展诉求。另外，Molecule 支持引用例如 [antd](http://ant.design/) 这类第三方的 UI 组件库，来满足自己的自定义诉求。
+Molecule provides many basic React UI Atomic Components such as [Menu][menu-url],[TreeView][treeview-url],[ContextMenu][ctxmenu-url],etc. At the same time, our Workbench UI is built on the basis of these components. Through these built-in components, we can meet the extension demands of out developers on UI to a greater extend. In addition, Molecule also supports the use of third-party UI component libraries like [antd](http://ant.design/), to meet its own custom requirements.
 
-目前我们使用了 Storybook 来开发维护这些组件，关于这些组件的使用，我们可以在源码仓库下的 [stories](https://github.com/DTStack/molecule/tree/main/stories) 中找到示例。
+Currently, we use Storybook to develop and maintain these components. Regarding the use of these components, we can find examples in [stories](https://github.com/DTStack/molecule/tree/main/stories) under the source code repository.
 
 [menu-url]: ./api/namespaces/molecule.component#menu
 [ctxmenu-url]: ./api/namespaces/molecule.component#usecontextmenu

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -4,46 +4,46 @@ sidebar_label: Quick Start
 sidebar_position: 2
 ---
 
-## 前置要求
+## Prerequisites
 
-> -   **Node.js 12.13.0 +** 版本
-> -   **React.js 16.14.0 +** 版本
-> -   [Yarn](https://yarnpkg.com/en/) - 推荐使用 **Yarn** 作为包管理
+> -   node.js version: **Node.js 12.13.0 +**
+> -   React.js version: **React.js 16.14.0 +**
+> -   [Yarn](https://yarnpkg.com/en/) - Recommend to use **Yarn** as package management
 
 :::info
-可以通过 `node -v` 命令查看当前 Node 版本。 推荐在 Mac 系统中使用 [nvm](https://github.com/nvm-sh/nvm) 来管理 Node.js 多版本
+use the `node -v` command to view the current Node version. It is recommended to use [nvm](https://github.com/nvm-sh/nvm) on Mac systems to manage multiple versions of Node.js.
 :::
 
-## 创建项目
+## Create a Project
 
-我们使用 React 官方推荐的 [create-react-app](https://github.com/facebook/create-react-app) 脚手架工具作为示例，
-这里我们**强烈推荐**使用 **Typescript** 模板：
+We use the [create-react-app](https://github.com/facebook/create-react-app) scaffolding tool officially recommended by React as an example,
+Here we **strongly recommend** the use of the **Typescript** template:
 
 ```bash
 npx create-react-app molecule-demo --template typescript
 ```
 
-这个命令会在当前目录下，创建一个叫 `molecule-demo` 的目录，切换到项目文件夹：
+This command will create a directory called `molecule-demo` in the current directory and switch to the project folder:
 
 ```bash
 cd molecule-demo
 ```
 
-## 安装 Molecule
+## Install Molecule
 
-然后，你需要安装 molecule 的依赖：
+Then, you need to install the dependency of molecule:
 
 ```bash
 yarn add @dtinsight/molecule
-# 或者
+# or
 npm install @dtinsight/molecule
 ```
 
-这个命令会在 `molecule-demo` 项目中自动安装 Molecule 的依赖。
+This command will automatically install Molecule's dependencies in the `molecule-demo` project.
 
-## 基本使用
+## Basic Use
 
-打开 `src/App.js` 文件，将该文件的内容替换成如下：
+Open the `src/App.js` file and replace the contents of the file with the following:
 
 ```js title="src/App.js"
 import React from 'react';
@@ -61,26 +61,26 @@ function App() {
 export default App;
 ```
 
-`extensions` 是需要自定义的扩展程序。
+`extensions` are extensions that need to be customized.
 
-## 启动项目
+## Startup Project
 
-最后，在终端中运行`start` 命令：
+Finally, run the `start` command in the terminal:
 
 ```bash
 yarn start
-# 或者 npm
+# or npm
 npm run start
 ```
 
-这个命令会自动在默认浏览器中打开 [http://localhost:3000](http://localhost:3000) 这个地址，即可看到 Molecule 默认的 IDE 界面。
+This command will automatically open the address [http://localhost:3000](http://localhost:3000) in the default browser, and you can see the default IDE interface of Molecule.
 
 ![molecule](/img/molecule.png)
 
-## 使用 Monaco Editor 语言包
+## Use Monaco Editor language pack
 
-使用 Monaco Editor 的语言包，需要使用插件 `monaco-editor-webpack-plugin`，所以这里我们得扩展下 **Webpack** 的默认配置。
-首先我们先安装 [react-app-rewired](https://github.com/timarney/react-app-rewired) 工具，然后在项目根目录创建一个`config-overrides.js` 文件，用来覆盖默认 Webpack 配置。 `monaco-editor-webpack-plugin` 插件具体使用如下：
+To use the language pack of Monaco Editor, you need to use the plug-in `monaco-editor-webpack-plugin`, so here we have to extend the default configuration of **Webpack**.
+First, we first install the [react-app-rewired](https://github.com/timarney/react-app-rewired) tool, and then create a `config-overrides.js` file in the project root directory to override the default Webpack configuration. The specific usage of the `monaco-editor-webpack-plugin` plugin is as follows:
 
 ```js title="config-overrides.js"
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
@@ -103,4 +103,4 @@ module.exports = function override(config, env) {
 };
 ```
 
-完整的代码示例，请查看 [molecule-demo](https://github.com/DTStack/molecule-examples/tree/main/packages/molecule-demo) 项目。
+For the complete code example, please check the [molecule-demo](https://github.com/DTStack/molecule-examples/tree/main/packages/molecule-demo) project.

--- a/website/docs/the-first-extension.md
+++ b/website/docs/the-first-extension.md
@@ -4,23 +4,24 @@ sidebar_label: The First Extension
 sidebar_position: 1
 ---
 
-在 Molecule 中，所有的自定义的功能，都是利用[扩展（Extension）](./guides/extension)来完成的。接下来让我们基于[molecule-demo][demo-url] 项目，快速学习一下如何编写一个扩展应用。
+In Molecule, all custom functions are done using [Extension](./guides/extension). Next, let us quickly learn how to write an extended application based on the [molecule-demo][demo-url] project.
 
 :::tip
-本文内容中的所有代码，都以 [Quick Start](./quick-start) 中的 [molecule-demo](https://github.com/DTStack/molecule-examples/tree/main/packages/molecule-demo) 项目为基础演示。
+All the codes are based on the [molecule-demo](https://github.com/DTStack/molecule-examples/tree/main/packages/molecule-demo) project in [Quick Start](./quick-start).
 :::
 
-## 一个简单的场景
+## A simple scene
 
 ![The First Extension](/img/the-first-extension.png)
 
-如图，我们在 **Explorer** 中的文件树（FolderTree）中展示了一系列的代码文件，当鼠标**点击**文件后，则在右侧的编辑器（Editor）中**打开**该文件。
+As shown in the figure, we display series of code files in the **FolderTree** of **Explorer**. When the file is **clicked** by the mouse, it will be **opened** in the Editor on the right.
 
-Molecule 默认内置了 [Explorer](./guides/extend-builtin-ui.md#浏览面板explorer)，[FolderTree][foldertree-url]，[Editor](./guides/extend-workbench#编辑器editor) 等基础 UI 模块，实现上图的功能，只需要通过其提供的 API，就可以快速实现这些需求，而开发者无需过多关心 UI 上的构建工作。
+Molecule has some UI modules such as [Explorer](./guides/extend-builtin-ui.md#浏览面板explorer)，[FolderTree][foldertree-url]，[Editor](./guides/extend-workbench#编辑器editor) built in by default.
+To achieve the functions in the above figure, these requirements can be quickly achieved through the API provided by it, and developers do not need to care too much about the construction of the UI.
 
-## 具体实现
+## Implementation
 
-首先，我们在 `src` 下新建一个 `extensions` 文件夹，然后创建一个 `theFirstExtension` 目录, 并添加默认模块 `index.ts`，如下：
+First, we create a new `extensions` folder under `src`, then create a `theFirstExtension` directory, and add the default module `index.ts`, as follows:
 
 ```bash
 src/extensions
@@ -30,9 +31,9 @@ src/extensions
     ├── index.ts
 ```
 
-### 创建扩展（Extension）对象
+### create Extension Object
 
-我们在 `index.ts` 中新建一个叫 `FirstExtension` 的类，该类实现类 [IExtension](./api/interfaces/molecule.model.IExtension) 接口：
+We create a new class called `FirstExtension` in `index.ts`, which implements the class [IExtension](./api/interfaces/molecule.model.IExtension) interface:
 
 ```ts title="src/extensions/theFirstExtension/index.ts"
 import { IExtension } from '@dtinsight/molecule/esm/model/extension';
@@ -54,18 +55,18 @@ export class FirstExtension implements IExtension {
 }
 ```
 
-上述代码中 `FirstExtension` 对象包含一个 `activate` 程序激活时所触发的方法，我们在这个方法中编写扩展程序的**初始化**逻辑； `dispose` 函数一般用于**取消**扩展程序时触发的方法，做一些**回收**的操作。我们使用 `folderTreeController` 分别执行了 `initFolderTree` 和 `handleSelectFolderTree` 方法，用来处理 [FolderTree][foldertree-url] 的**数据初始化**和**事件监听**。
+The code snippet above shows that the class `FirstExtension` includes a method named `activate` that will be running when the program is activated. We write the **initialization** logic of the extension in this method;`dispose` is normally used to **cancel** extension programme and do some **recycling** operations. Importing `folderTreeController` including methods called `initFolderTree` and `handleSelectFolderTree` is used to process the **data initialization** and **event monitoring** of [FolderTree][foldertree-url].
 
 :::info
-更多关于 **Extension** 的介绍内容，请参考 [Guides](./guides/extension.md)
+For more details about the **Extension**, please refer to [Guides](./guides/extension.md).
 :::
 
-### 编写控制逻辑
+### Write control logic
 
-我们来看看 `folderTreeController` 模块的具体实现逻辑：
+Let's have a look at the specific implementation logic of the `folderTreeController` module:
 
--   `initFolderTree`： 负责获取 [FolderTree][foldertree-url] 的数据，成功后并渲染数据到 [FolderTree][foldertree-url] 组件
--   `handleSelectFolderTree`： 负责处理 [FolderTree][foldertree-url] 的 `onSelectFile` 事件，选中后文件，在 [Editor](./api/namespaces/molecule#editor) 中打开
+-   `initFolderTree`： Responsible for obtaining the data of [FolderTree][foldertree-url], and rendering the data to the [FolderTree][foldertree-url] component after success
+-   `handleSelectFolderTree`： Responsible for handling the `onSelectFile` event of [FolderTree][foldertree-url], after selecting the file, open it in [Editor](./api/namespaces/molecule#editor)
 
 ```ts title="/src/extensions/theFirstExtension/folderTreeController.ts"
 import molecule from '@dtinsight/molecule';
@@ -90,15 +91,15 @@ export function handleSelectFolderTree() {
 }
 ```
 
-在`API.getFolderTree` 方法获取文件树数据成功后，我们通过 [`molecule.folderTree.add`](./api/classes/molecule.FolderTreeService#add) 方法，将数据添加并展示到 [FolderTree](./api/classes/molecule.FolderTreeService) 组件中；通过 [`molecule.folderTree.onSelectFile`](./api/classes/molecule.FolderTreeService#onSelectFile) 方法监听**选中文件**；最后通过 [`molecule.editor.open`](./api/interfaces/molecule.IEditorService#open) 方法打开文件。
+After fetching the data of FolderTree successfully through `API.getFolderTree` ,we use the [`molecule.folderTree.add`](./api/classes/molecule.FolderTreeService#add) method to add and display data to the [FolderTree] component; next, monitor **the selected file** through the [`molecule.folderTree.onSelectFile`](./api/classes/molecule.FolderTreeService#onSelectFile) method; finally,open the file through the [`molecule.editor.open`](./api/interfaces/molecule.IEditorService#open) method.
 
 :::caution
-需要注意的是，在现实情况中，`API.getFolderTree` 返回的**数据类型**并不是 [IFolderTreeNodeProps](./api/interfaces/molecule.model.IFolderTreeNodeProps) 类型，我们往往需要经过一个**转换**方法。示例中 `API.getFolderTree` 函数的 Mock 数据可以[查看](https://github.com/DTStack/molecule-examples/blob/main/packages/molecule-demo/public/mock/folderTree.json)。`handleSelectFolderTree` 方法中的 `transformToEditorTab` 为一个**转换**方法，主要是将`file`转换为[IEditorTab](./api/interfaces/molecule.model.IEditorTab) 类型。
+Pay more attention: In reality, the **data type** returned by `API.getFolderTree` is not [IFolderTreeNodeProps](./api/interfaces/molecule.model.IFolderTreeNodeProps) type, we often need to go through a **conversion** method. The mock data of the `API.getFolderTree` function in the example can be [View](https://github.com/DTStack/molecule-examples/blob/main/packages/molecule-demo/public/mock/folderTree.json). The `transformToEditorTab` in the `handleSelectFolderTree` method is a **transformation** method, which mainly converts `file` to [IEditorTab](./api/interfaces/molecule.model.IEditorTab) type.
 :::
 
-### 使用扩展
+### Use extension
 
-定义好的 `FirstExtension` 对象，最后需要配合 [MoleculeProvider][provider-url] 来使用。这里我们默认在 `extensions/index.ts` 中导出所有需要加载的**扩展对象**：
+After defining class `FirstExtension`, it is used with [MoleculeProvider][provider-url]. Here we export all **extension objects** that need to be loaded in `extensions/index.ts` by default:
 
 ```ts title="/src/extensions/index.ts"
 import { IExtension } from '@dtinsight/molecule/esm/model';
@@ -109,7 +110,7 @@ const extensions: IExtension[] = [new FirstExtension()];
 export default extensions;
 ```
 
-导入 `FirstExtension` 对象并将其实例化，最后使用 `extensions` 导出所有**扩展对象实例**。
+Import the `FirstExtension` object and instantiate it, and finally use `extensions` to export all **extension object instances**.
 
 ```tsx title="/src/app.tsx"
 import extensions from './extensions';
@@ -119,19 +120,20 @@ import extensions from './extensions';
 </MoleculeProvider>;
 ```
 
-最后，引入 `extensions` 并传入 [MoleculeProvider][provider-url] 的 `extensions` 属性。
+Finally, introduce `extensions` and pass in the `extensions` property of [MoleculeProvider][provider-url].
 
 :::info
-上例只是一个很简单的应用场景，想要实现对 [Workbench](/guides/extend-workbench.md) 更丰富的扩展，可以参考 [工作台扩展指南](./guides/extend-workbench.md)。
+The above example is just a very simple application scenario. If you want to achieve a richer extension to [Workbench](/guides/extend-workbench.md), you can refer to [Workbench Extension Guide](./guides/extend-workbench.md) ).
 
-另外，[**Extension**](./guides/extension.md) 为 Molecule 中非常重要的概念，通过它我们才可以完成对 [**ColorTheme**](./guides/extend-color-theme.md), [**Workbench**](guides/extend-workbench.md), [**i18n**](./guides/extend-locales.md),
-[**Settings**](./guides/extend-settings.md), [**Keybindings**](./guides/extend-keybinding.md), [**QuickAccess**](./guides/extend-quick-access.md) 等等核心模块的扩展。
+Otherwise,[**Extension**](./guides/extension.md) is the quite important concept in Molecule.
+Through it, we can extend many core modules such as [**ColorTheme**](./guides/extend-color-theme.md), [**Workbench**](guides/extend-workbench.md), [**i18n**](./guides/extend-locales.md),
+[**Settings**](./guides/extend-settings.md), [**Keybindings**](./guides/extend-keybinding.md), [**QuickAccess**](./guides/extend-quick-access.md)
 
 :::
 
-## 完整示例
+## Complete Example
 
-**第一个扩展**的完整源码，请[浏览][demo-url]。
+Please [view][demo-url] the complete source code of **First Extension**
 
 [demo-url]: https://github.com/DTStack/molecule-examples/tree/main/packages/molecule-demo/src/extensions/theFirstExtension
 [foldertree-url]: ./guides/extend-builtin-ui#文件树foldertree


### PR DESCRIPTION
## Description

translate two parts of documents to English

Fixes # (issue)

## Changes

OverView and Quick-Start have been translated to English.

-   Change A
-   Change B
