### PR TITLE
feat: remove the onRemove processing logic in the built-in FolderTree extension

### DIFF
--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -5,10 +5,6 @@ export const ExtendsFolderTree: IExtension = {
     id: 'ExtendsFolderTree',
     name: 'Extends FolderTree',
     activate() {
-        molecule.folderTree.onRemove((id) => {
-            molecule.folderTree.remove(id);
-        });
-
         molecule.folderTree.onRename((id) => {
             molecule.folderTree.update({
                 id,

--- a/stories/extensions/test/index.tsx
+++ b/stories/extensions/test/index.tsx
@@ -172,5 +172,9 @@ export const ExtendsTestPane: IExtension = {
             };
             molecule.editor.open(tabData);
         });
+
+        molecule.folderTree.onRemove((id) => {
+            molecule.folderTree.remove(id);
+        });
     },
 };

--- a/website/docs/guides/extend-builtin-ui.md
+++ b/website/docs/guides/extend-builtin-ui.md
@@ -107,6 +107,10 @@ molecule.folderTree.onSelectFile((file: IFolderTreeNodeProps) => {
 
 For more information about the use of FolderTree, please refer to the [API](../api/classes/molecule.FolderTreeService) documentation.
 
+:::caution
+We don't have default node removal logic built into FolderTree, but you can customize it using the `onRemove` method.
+:::
+
 ## [EditorTree](../api/interfaces/molecule.IEditorTreeService)
 
 [EditorTree](../api/interfaces/molecule.IEditorTreeService) is responsible for displaying some **editing tags** currently working in [Explorer](#explorer). Molecule currently does not provide too many APIs to support the extension of this UI, but more basic **event handling**.

--- a/website/docs/guides/extend-builtin-ui.md
+++ b/website/docs/guides/extend-builtin-ui.md
@@ -108,7 +108,7 @@ molecule.folderTree.onSelectFile((file: IFolderTreeNodeProps) => {
 For more information about the use of FolderTree, please refer to the [API](../api/classes/molecule.FolderTreeService) documentation.
 
 :::caution
-We don't have default node removal logic built into FolderTree, but you can customize it using the `onRemove` method.
+We don't have default node removal logic built into FolderTree, but you can customize it using `remove` method.
 :::
 
 ## [EditorTree](../api/interfaces/molecule.IEditorTreeService)

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/extend-builtin-ui.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/extend-builtin-ui.md
@@ -109,7 +109,7 @@ molecule.folderTree.onSelectFile((file: IFolderTreeNodeProps) => {
 更多关于 FolderTree 的使用，请参考 [API](../api/classes/molecule.FolderTreeService) 文档。
 
 :::caution
-我们没有在 FolderTree 中内置默认的节点移除逻辑，开发者可以使用 `onRemove` 方法来自定义。
+我们没有在 FolderTree 中内置默认的节点移除逻辑，开发者可以使用 `remove` 方法来自定义。
 :::
 
 ## [编辑器树（EditorTree)](../api/interfaces/molecule.IEditorTreeService)

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/extend-builtin-ui.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/extend-builtin-ui.md
@@ -108,6 +108,10 @@ molecule.folderTree.onSelectFile((file: IFolderTreeNodeProps) => {
 
 更多关于 FolderTree 的使用，请参考 [API](../api/classes/molecule.FolderTreeService) 文档。
 
+:::caution
+我们没有在 FolderTree 中内置默认的节点移除逻辑，开发者可以使用 `onRemove` 方法来自定义。
+:::
+
 ## [编辑器树（EditorTree)](../api/interfaces/molecule.IEditorTreeService)
 
 [EditorTree](../api/interfaces/molecule.IEditorTreeService) 是 [Explorer](#浏览面板explorer) 中负责展示当前正在工作的一些**编辑标签**。Molecule 目前并未提供太多的 API 来支持扩展这个 UI, 更多还是一些基本的**事件处理**。


### PR DESCRIPTION

## Description

Move the node removal logic from the built-in FolderTree extension to the test extension.

Fixes #583 
