### PR TITLE
refactor(connector): filter the useless properties of Controller

### DIFF
--- a/src/controller/__tests__/menuBar.test.ts
+++ b/src/controller/__tests__/menuBar.test.ts
@@ -41,7 +41,7 @@ describe('The menuBar controller', () => {
     test('Should support to update the focusin element', () => {
         menuBarController.updateFocusinEle(mockEle);
 
-        expect((menuBarController as any).focusinEle).toBe(mockEle);
+        expect((menuBarController as any)._focusinEle).toBe(mockEle);
     });
 
     test('Should support to execute the onClick method', () => {

--- a/src/controller/menuBar.ts
+++ b/src/controller/menuBar.ts
@@ -44,9 +44,9 @@ export class MenuBarController
     private readonly monacoService: IMonacoService;
     private readonly builtinService: IBuiltinService;
     private readonly activityBarService: IActivityBarService;
-    private focusinEle: HTMLElement | null = null;
 
-    private automation = {};
+    private _focusinEle: HTMLElement | null = null;
+    private _automation = {};
 
     constructor() {
         super();
@@ -103,7 +103,7 @@ export class MenuBarController
             ],
         ] as [string, () => void][]).forEach(([key, value]) => {
             if (key) {
-                this.automation[key] = value;
+                this._automation[key] = value;
             }
         });
 
@@ -112,7 +112,7 @@ export class MenuBarController
 
     public updateFocusinEle = (ele: HTMLElement | null) => {
         if (ele?.id == ID_APP) return;
-        this.focusinEle = ele;
+        this._focusinEle = ele;
     };
 
     public readonly onClick = (event: React.MouseEvent, item: IMenuBarItem) => {
@@ -124,7 +124,7 @@ export class MenuBarController
          * 2、we have no way of knowing whether user-defined events are executed internally
          */
         this.emit(MenuBarEvent.onSelect, menuId);
-        this.automation[menuId]?.();
+        this._automation[menuId]?.();
 
         // Update the check status of MenuBar in the contextmenu of ActivityBar
         this.updateActivityBarContextMenu(menuId);
@@ -144,7 +144,7 @@ export class MenuBarController
         if (ACTION_QUICK_UNDO) {
             this.monacoService.commandService.executeCommand(
                 ACTION_QUICK_UNDO,
-                this.focusinEle
+                this._focusinEle
             );
         }
     };
@@ -154,7 +154,7 @@ export class MenuBarController
         if (ACTION_QUICK_REDO) {
             this.monacoService.commandService.executeCommand(
                 ACTION_QUICK_REDO,
-                this.focusinEle
+                this._focusinEle
             );
         }
     };
@@ -183,7 +183,7 @@ export class MenuBarController
         if (ACTION_QUICK_SELECT_ALL) {
             this.monacoService.commandService.executeCommand(
                 ACTION_QUICK_SELECT_ALL,
-                this.focusinEle
+                this._focusinEle
             );
         }
     };

--- a/src/react/connector.tsx
+++ b/src/react/connector.tsx
@@ -85,7 +85,7 @@ export function connect<T = any>(
             }
         }
 
-        getControllers() {
+        getControllerProperties() {
             const target = {};
             if (!Controller) {
                 return target;
@@ -129,7 +129,7 @@ export function connect<T = any>(
                     {...this.state}
                     {...this.props}
                     {...this.getServiceState()}
-                    {...this.getControllers()}
+                    {...this.getControllerProperties()}
                 />
             );
         }


### PR DESCRIPTION
## Description

过滤无用的控制器属性，仅仅保留**事件**方法，**公共属性**

Fixes #634 

## Changes

-   Connector 增加 `getObjectPublicProperties` 过滤方法
-   Connector 修改继承 Controller 属性的方法
