### PR TITLE
feat: LocaleNotification supports to trigger reload by pressing the Enter key

### DIFF
--- a/src/workbench/notification/__tests__/__snapshots__/localeNotification.test.tsx.snap
+++ b/src/workbench/notification/__tests__/__snapshots__/localeNotification.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`The LocaleNotification Component Match Snapshot 1`] = `
   style={
     Object {
       "lineHeight": "1.5",
-      "textAlign": "left",
+      "textAlign": "right",
       "width": 420,
     }
   }
@@ -14,6 +14,7 @@ exports[`The LocaleNotification Component Match Snapshot 1`] = `
     style={
       Object {
         "direction": "ltr",
+        "textAlign": "left",
         "whiteSpace": "normal",
       }
     }
@@ -33,16 +34,28 @@ exports[`The LocaleNotification Component Match Snapshot 1`] = `
       Notice: Reload the Page could lose the data, Please confirm you have saved before.
     </p>
   </div>
-  <a
-    className="mo-btn mo-btn--normal"
-    onClick={[Function]}
+  <div
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
-        "width": 150,
+        "display": "inline-block",
+        "marginBottom": 2,
       }
     }
+    tabIndex={0}
   >
-    Confirm Reload
-  </a>
+    <a
+      className="mo-btn mo-btn--normal"
+      onClick={[Function]}
+      style={
+        Object {
+          "width": 150,
+        }
+      }
+    >
+      Confirm Reload
+    </a>
+  </div>
 </div>
 `;

--- a/src/workbench/notification/__tests__/__snapshots__/localeNotification.test.tsx.snap
+++ b/src/workbench/notification/__tests__/__snapshots__/localeNotification.test.tsx.snap
@@ -6,24 +6,33 @@ exports[`The LocaleNotification Component Match Snapshot 1`] = `
     Object {
       "lineHeight": "1.5",
       "textAlign": "left",
-      "width": 350,
+      "width": 420,
     }
   }
 >
-  <p>
-    The current locale has changed to 
-    chinese
-    , click the button to reload the Page and applying the changes.
-  </p>
-  <p
+  <div
     style={
       Object {
-        "fontWeight": "bold",
+        "direction": "ltr",
+        "whiteSpace": "normal",
       }
     }
   >
-    Notice: Reload the Page could lose the data, Please confirm you have saved before.
-  </p>
+    <p>
+      The current locale has changed to 
+      chinese
+      , click the button to reload the Page and applying the changes.
+    </p>
+    <p
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Notice: Reload the Page could lose the data, Please confirm you have saved before.
+    </p>
+  </div>
   <a
     className="mo-btn mo-btn--normal"
     onClick={[Function]}

--- a/src/workbench/notification/__tests__/localeNotification.test.tsx
+++ b/src/workbench/notification/__tests__/localeNotification.test.tsx
@@ -26,4 +26,22 @@ describe('The LocaleNotification Component', () => {
 
         window.location.reload = originalFunction;
     });
+
+    test('Should support to reload by pressing the Enter key.', async () => {
+        const originalFunction = window.location.reload;
+        const mockFn = jest.fn();
+        render(<LocaleNotification locale="zh-CN" />);
+        window.location.reload = mockFn;
+
+        await new Promise((resolve) => {
+            setTimeout(() => {
+                fireEvent.keyDown(document, { key: 'Enter', code: 'Enter' });
+                fireEvent.keyUp(document, { key: 'Enter', code: 'Enter' });
+                resolve(true);
+            }, 1000);
+        });
+
+        expect(mockFn).toBeCalled();
+        window.location.reload = originalFunction;
+    });
 });

--- a/src/workbench/notification/__tests__/localeNotification.test.tsx
+++ b/src/workbench/notification/__tests__/localeNotification.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { create } from 'react-test-renderer';
 import LocaleNotification from '../notificationPane/localeNotification';
@@ -35,18 +35,16 @@ describe('The LocaleNotification Component', () => {
             writable: true,
             value: { reload: mockFn },
         });
-        render(<LocaleNotification locale="zh-CN" />);
+        const { getByText } = render(<LocaleNotification locale="zh-CN" />);
+        const elem = getByText('Confirm Reload');
 
-        await new Promise((resolve) => {
-            setTimeout(() => {
-                fireEvent.keyDown(document, { key: 'Enter', code: 'Enter' });
-                fireEvent.keyUp(document, { key: 'Enter', code: 'Enter' });
-                resolve(true);
-            }, 1000);
+        await waitFor(() => {
+            fireEvent.keyDown(elem, { key: 'Enter', code: 'Enter' });
+            fireEvent.keyUp(elem, { key: 'Enter', code: 'Enter' });
+
+            expect(jest.isMockFunction(window.location.reload)).toBeTruthy();
+            expect(mockFn).toBeCalled();
         });
-
-        expect(jest.isMockFunction(window.location.reload)).toBeTruthy();
-        expect(mockFn).toBeCalled();
 
         window.location.reload = originalFunction;
     });

--- a/src/workbench/notification/__tests__/localeNotification.test.tsx
+++ b/src/workbench/notification/__tests__/localeNotification.test.tsx
@@ -30,8 +30,12 @@ describe('The LocaleNotification Component', () => {
     test('Should support to reload by pressing the Enter key.', async () => {
         const originalFunction = window.location.reload;
         const mockFn = jest.fn();
+        Reflect.deleteProperty(window, 'location');
+        Object.defineProperty(window, 'location', {
+            writable: true,
+            value: { reload: mockFn },
+        });
         render(<LocaleNotification locale="zh-CN" />);
-        window.location.reload = mockFn;
 
         await new Promise((resolve) => {
             setTimeout(() => {
@@ -41,7 +45,9 @@ describe('The LocaleNotification Component', () => {
             }, 1000);
         });
 
+        expect(jest.isMockFunction(window.location.reload)).toBeTruthy();
         expect(mockFn).toBeCalled();
+
         window.location.reload = originalFunction;
     });
 });

--- a/src/workbench/notification/notificationPane/localeNotification.tsx
+++ b/src/workbench/notification/notificationPane/localeNotification.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'mo/components';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 interface ILocaleNotificationProps {
     locale: string;
@@ -12,22 +12,66 @@ export function LocaleNotification(props: ILocaleNotificationProps) {
         window.location.reload();
     }, []);
 
+    // Support to reload by pressing the Enter key.
+    useEffect(() => {
+        const startTime = new Date().getTime();
+        let lastKeyDownTime = startTime;
+        let isOkToReload = false;
+
+        // By default, the delay is set to 1000 milliseconds to prevent the refresh
+        // from being triggered by mistake when the locale is switched by the Enter key
+        // and the Enter key is held down for a long time.
+        let delay = 1000;
+
+        // When the locale is switched by the Enter key, this function will be triggered once.
+        const handleKeyUp = (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && isOkToReload) {
+                reload();
+            }
+
+            // Change the delay to 200, so that it can quickly respond to
+            // the next operation of pressing the Enter key to refresh.
+            delay = 200;
+        };
+
+        // When the Enter key is pressed, determine if it can be reloaded
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key !== 'Enter' || isOkToReload) return;
+
+            const keyDownTime = new Date().getTime();
+            if (keyDownTime - lastKeyDownTime > delay) {
+                isOkToReload = true;
+            }
+            lastKeyDownTime = keyDownTime;
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        document.addEventListener('keyup', handleKeyUp);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.removeEventListener('keyup', handleKeyUp);
+        };
+    }, []);
+
     return (
         <div
             style={{
                 lineHeight: '1.5',
-                width: 350,
+                width: 420,
                 textAlign: 'left',
             }}
         >
-            <p>
-                The current locale has changed to {locale}, click the button to
-                reload the Page and applying the changes.
-            </p>
-            <p style={{ fontWeight: 'bold' }}>
-                Notice: Reload the Page could lose the data, Please confirm you
-                have saved before.
-            </p>
+            <div style={{ direction: 'ltr', whiteSpace: 'normal' }}>
+                <p>
+                    The current locale has changed to {locale}, click the button
+                    to reload the Page and applying the changes.
+                </p>
+                <p style={{ fontWeight: 'bold' }}>
+                    Notice: Reload the Page could lose the data, Please confirm
+                    you have saved before.
+                </p>
+            </div>
             <Button style={{ width: 150 }} onClick={reload}>
                 Confirm Reload
             </Button>

--- a/src/workbench/notification/notificationPane/localeNotification.tsx
+++ b/src/workbench/notification/notificationPane/localeNotification.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'mo/components';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 interface ILocaleNotificationProps {
     locale: string;
@@ -12,57 +12,42 @@ export function LocaleNotification(props: ILocaleNotificationProps) {
         window.location.reload();
     }, []);
 
-    // Support to reload by pressing the Enter key.
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
     useEffect(() => {
-        const startTime = new Date().getTime();
-        let lastKeyDownTime = startTime;
-        let isOkToReload = false;
-
-        // By default, the delay is set to 1000 milliseconds to prevent the refresh
-        // from being triggered by mistake when the locale is switched by the Enter key
-        // and the Enter key is held down for a long time.
-        let delay = 1000;
-
-        // When the locale is switched by the Enter key, this function will be triggered once.
-        const handleKeyUp = (e: KeyboardEvent) => {
-            if (e.key === 'Enter' && isOkToReload) {
-                reload();
-            }
-
-            // Change the delay to 200, so that it can quickly respond to
-            // the next operation of pressing the Enter key to refresh.
-            delay = 200;
-        };
-
-        // When the Enter key is pressed, determine if it can be reloaded
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key !== 'Enter' || isOkToReload) return;
-
-            const keyDownTime = new Date().getTime();
-            if (keyDownTime - lastKeyDownTime > delay) {
-                isOkToReload = true;
-            }
-            lastKeyDownTime = keyDownTime;
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        document.addEventListener('keyup', handleKeyUp);
-
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-            document.removeEventListener('keyup', handleKeyUp);
-        };
+        // Delay execution to ensure focus on element
+        setTimeout(() => wrapperRef.current?.focus());
     }, []);
+
+    let isOkToReload = false;
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            isOkToReload = true;
+        }
+    };
+
+    const handleKeyUp = (e) => {
+        if (e.key === 'Enter' && isOkToReload) {
+            reload();
+        }
+    };
 
     return (
         <div
             style={{
                 lineHeight: '1.5',
                 width: 420,
-                textAlign: 'left',
+                textAlign: 'right',
             }}
         >
-            <div style={{ direction: 'ltr', whiteSpace: 'normal' }}>
+            <div
+                style={{
+                    direction: 'ltr',
+                    whiteSpace: 'normal',
+                    textAlign: 'left',
+                }}
+            >
                 <p>
                     The current locale has changed to {locale}, click the button
                     to reload the Page and applying the changes.
@@ -72,9 +57,18 @@ export function LocaleNotification(props: ILocaleNotificationProps) {
                     you have saved before.
                 </p>
             </div>
-            <Button style={{ width: 150 }} onClick={reload}>
-                Confirm Reload
-            </Button>
+            <div
+                ref={wrapperRef}
+                // make it focusable
+                tabIndex={0}
+                onKeyDown={handleKeyDown}
+                onKeyUp={handleKeyUp}
+                style={{ display: 'inline-block', marginBottom: 2 }}
+            >
+                <Button style={{ width: 150 }} onClick={reload}>
+                    Confirm Reload
+                </Button>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Description

LocaleNotification supports to trigger reload by pressing the Enter key.

Fixes #616 

## Changes

-   LocaleNotification supports to trigger reload by pressing the Enter key.
-   Optimize the style and layout of LocaleNotification.
