### PR TITLE
fix: the context menu does not close when the context menu item is clicked.

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -103,7 +103,7 @@ function MenuComp(props: React.PropsWithChildren<IMenuProps>, ref) {
                     );
                 }
                 return (
-                    <MenuItem key={item.id} onClick={handleClick} {...item}>
+                    <MenuItem {...item} key={item.id} onClick={handleClick}>
                         {item.name}
                     </MenuItem>
                 );


### PR DESCRIPTION
## Description

Fix the issue that the onClick property of MenuItem will be overridden by custom data.
