### PR TITLE
fix: fix panels didn't active the next one after closing automatically

### DIFF
--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -156,7 +156,10 @@ export function Tab({ tab, active, ...restEvents }: ITabComponent) {
                         tabItemClassName,
                         status ? 'status' : 'op'
                     )}
-                    onClick={() => onCloseTab?.(id)}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onCloseTab?.(id);
+                    }}
                     renderStatus={(isHover) => renderStatus(status, isHover)}
                 />
             )}

--- a/src/components/tabs/tabExtra.tsx
+++ b/src/components/tabs/tabExtra.tsx
@@ -3,7 +3,7 @@ import { getBEMElement } from 'mo/common/className';
 
 interface ITabExtraProps {
     classNames?: string;
-    onClick?: () => void;
+    onClick?: React.MouseEventHandler<HTMLDivElement>;
     renderStatus?: (hover: boolean) => JSX.Element;
 }
 

--- a/src/controller/panel.tsx
+++ b/src/controller/panel.tsx
@@ -66,11 +66,8 @@ export class PanelController extends Controller implements IPanelController {
     }
 
     public readonly onTabChange = (key: UniqueId): void => {
-        const state = this.panelService.getState();
         if (key) {
-            this.panelService.setState({
-                current: state.data?.find((item) => item.id === key),
-            });
+            this.panelService.setActive(key);
         }
         this.emit(PanelEvent.onTabChange, key);
     };


### PR DESCRIPTION
### 简介
- 修复 panel 关闭后无法自动选择下一个 panel 的问题
- 优化 `onTabChange` 事件

### 主要变更
- 无法自动选择的原因是在点击 close 图标的时候，同时触发了 `onClose` 和 `onTabChange` 两个事件，两个事件都修改了 current 的值，按照冒泡的时间顺序，先触发 `onClose` 的 current 修改，然后是 `onTabChange` 的 current 修改，导致 bug。只需要取消 `onClose` 事件的冒泡即可