### PR TITLE
fix: improve the style of the EditorTree node's icon

### DIFF
--- a/src/workbench/sidebar/explore/style.scss
+++ b/src/workbench/sidebar/explore/style.scss
@@ -104,6 +104,7 @@
 
         &__fileName {
             flex-basis: auto;
+            margin-left: 5px;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: pre;
@@ -154,6 +155,7 @@
 
     &__close {
         color: var(--icon-foreground);
+        margin-right: 2px;
         opacity: 0;
 
         &:hover {
@@ -165,7 +167,6 @@
         flex-shrink: 0;
         height: 22px;
         line-height: 23px;
-        margin: 0 5px 0 3px;
         width: 16px;
     }
 }


### PR DESCRIPTION
## Description

Improve the style of the EditorTree node's icon
