### PR TITLE
ci: add  action for github page  deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+    push:
+        branches: [master]
+        paths: [website/**]
+
+jobs:
+    deploy:
+        name: Deploy to GitHub Pages
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 14.x
+                  cache: yarn
+                  cache-dependency-path: website/yarn.lock
+            - name: Build website
+              working-directory: website
+              run: |
+                  yarn install --frozen-lockfile
+                  yarn build
+
+            # Popular action to deploy to GitHub Pages:
+            # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  # Build output to publish to the `gh-pages` branch:
+                  publish_dir: website/build
+                  # Assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch:
+                  # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+                  # The GH actions bot is used by default if you didn't specify the two fields.
+                  # You can swap them out with your own user credentials.
+                  user_name: github-actions[bot]
+                  user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,23 @@
+name: Test GitHub Pages Deployment
+
+on:
+    pull_request:
+        branches: [master]
+        paths: [website/**]
+
+jobs:
+    test-deploy:
+        name: Test deployment
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 14.x
+                  cache: yarn
+                  cache-dependency-path: website/yarn.lock
+            - name: Test build
+              working-directory: website
+              run: |
+                  yarn install --frozen-lockfile
+                  yarn build

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
         "release": "standard-version",
         "precommit": "pretty-quick --staged && npm run check-types",
         "docs": "typedoc --entryPoints src/index.ts --out docs/api --name 'Molecule API'",
-        "web": "webpack serve --env prod --config ./build/web.js",
-        "deploy": "gh-pages -d website/build"
+        "web": "webpack serve --env prod --config ./build/web.js"
     },
     "keywords": [
         "react.js",


### PR DESCRIPTION
## Overview

Add **deployment** action for `gh-pages`, it refers to the below document:

https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions


## Changes

-  Add `deploy.yml` for deployment `gh-pages` when website content changed
-  Add `test-deploy.yml` to test the build of website content
