### PR TITLE
fix: make Keybinding work after reloading Molecule

### DIFF
--- a/src/common/__tests__/dom.test.ts
+++ b/src/common/__tests__/dom.test.ts
@@ -1,4 +1,8 @@
-import { findParentByClassName, getPositionByPlacement } from '../dom';
+import {
+    findParentByClassName,
+    getPositionByPlacement,
+    getElementClientCenter,
+} from '../dom';
 
 describe('Test functions in dom.ts', () => {
     test('The getPositionByPlacement function', () => {
@@ -46,5 +50,24 @@ describe('Test functions in dom.ts', () => {
         expect(() => {
             findParentByClassName(1, 'test');
         }).toThrowError();
+    });
+
+    test('The getElementClientCenter function', () => {
+        const elem = document.createElement('div');
+        const domRect = {
+            x: 10,
+            y: 10,
+            width: 10,
+            height: 10,
+            top: 10,
+            right: 10,
+            bottom: 10,
+            left: 10,
+        } as DOMRect;
+        elem.getBoundingClientRect = jest.fn(() => domRect);
+
+        const center = getElementClientCenter(elem);
+        expect(center.x).toEqual(15);
+        expect(center.y).toEqual(15);
     });
 });

--- a/src/common/__tests__/utils.test.ts
+++ b/src/common/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
-import { normalizeFlattedObject, colorLightOrDark } from '../utils';
+import {
+    normalizeFlattedObject,
+    colorLightOrDark,
+    cloneInstance,
+} from '../utils';
 
 describe('Test Utils', () => {
     test('The normalizeFlattedObject function', () => {
@@ -39,5 +43,11 @@ describe('Test Utils', () => {
     test('The colorLightOrDark function', () => {
         expect(colorLightOrDark('#000')).toBe('dark');
         expect(colorLightOrDark('rgb(255,255,255)')).toBe('light');
+    });
+
+    test('The cloneInstance function', () => {
+        const obj1 = { name: 'test' };
+        const obj2 = cloneInstance(obj1);
+        expect(obj1.name).toEqual(obj2.name);
     });
 });

--- a/src/provider/molecule.tsx
+++ b/src/provider/molecule.tsx
@@ -48,6 +48,10 @@ export class MoleculeProvider extends Component<IMoleculeProps> {
     }
 
     componentDidMount() {
+        // The monacoService needs to be initialized each time the MoleculeProvider is loaded to
+        // ensure that Keybinding events can be bound to the latest dom.
+        this.monacoService.initWorkspace(this.layoutService.container!);
+
         if (!this.extensionService.isLoaded()) {
             this.initialize();
         }
@@ -58,9 +62,6 @@ export class MoleculeProvider extends Component<IMoleculeProps> {
 
         const [languages, restExts] =
             this.extensionService.splitLanguagesExts(extensions);
-
-        // First to init the monacoService
-        this.monacoService.initWorkspace(this.layoutService.container!);
 
         // Molecule should load the language extensions first to
         // ensure that the custom language extensions is registered in localeService

--- a/src/services/workbench/layoutService.ts
+++ b/src/services/workbench/layoutService.ts
@@ -88,9 +88,8 @@ export class LayoutService
     }
 
     public get container() {
-        if (!this._container) {
-            this._container = document.getElementById(ID_APP) || document.body;
-        }
+        // Make sure to get the latest dom element.
+        this._container = document.getElementById(ID_APP) || document.body;
         return this._container;
     }
 


### PR DESCRIPTION
## 简介

修复重载Molecule后Keybinding功能失效问题。
`说明：Keybinding功能之所以会失效，是因为Molecule重载后重新渲染了dom，导致原先注册并绑定到dom上的监听事件丢失了。`

Fixes #612 

## 变更

-   每次加载MoleculeProvider时都执行一次monacoService的初始化，以确保能将Keybinding事件绑定到dom上。
-   layoutService中的container改为每次都去查找最新的dom，以确保初始化monacoService时拿到的是最新的dom。
