### PR TITLE
fix: prevent the editor from initializing when switching tabs

### DIFF
--- a/src/workbench/editor/group.tsx
+++ b/src/workbench/editor/group.tsx
@@ -120,7 +120,6 @@ export function EditorGroup(props: IEditorGroupProps & IEditorController) {
                         )
                     ) : (
                         <MonacoEditor
-                            key={tab?.id}
                             options={{
                                 ...editorOptions,
                                 value: tab?.data?.value,


### PR DESCRIPTION
## 简介

修复切换editor tab时editor总是会初始化的问题。

Fixes #663 

## 变更

-   去掉传给MonacoEditor的key属性（因为切换tab时会导致key变化，从而导致初始化）
