### PR TITLE
fix: yarn web failed in windows

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -13,7 +13,10 @@ function replacePath(code, filePath, importOptions) {
     const sourcePath = path.dirname(filePath);
     const targetPath = path.resolve(output);
     const relativePath = path.relative(sourcePath, targetPath);
-    const finalPath = relativePath ? './' + relativePath + '/' : './';
+    // transform different platform separator to linux's separator
+    const finalPath = relativePath
+        ? './' + relativePath.split(path.sep).join('/') + '/'
+        : './';
     return code.replace(/([from|import]\s+)'(mo\/|\bmo\b)/g, "$1'" + finalPath);
 }
 


### PR DESCRIPTION
### 简介
- 修复 windows 下运行 web 命令失败的问题


### 主要变更
- 原因是因为执行 `build:esm` 后，在 windows 下路径分割符是 `\`， 'mo/common/xxx'  路径会转化成 '..\..\..\common/xxx' 这种路径，而 '\' 是转译的，导致出现问题

Actually:

`windows` 下的 `esm/workbench/editor/welcome/index.js` 文件内容中部分如下：
<img width="453" alt="image" src="https://user-images.githubusercontent.com/18719701/161890469-371247b3-e2f4-45bf-9cfd-c7288ca27ed3.png">

Expected:
```js
import { prefixClaName } from './../../../common/className';
```


### Related Issues
Closed #718 