### PR TITLE
fix: throws the full Error message when the Extension load exception

### DIFF
--- a/packages/ide/src/services/extensionService.ts
+++ b/packages/ide/src/services/extensionService.ts
@@ -179,7 +179,7 @@ export class ExtensionService implements IExtensionService {
             // Then activate
             this.activate(unloadExtensions);
         } catch (e) {
-            logger.error(ErrorMsg.LoadExtensionFail);
+            logger.error(ErrorMsg.LoadExtensionFail, e);
         }
     }
 


### PR DESCRIPTION
## Description

Throws the full Error message when the Extension load exception

Fixes #710 

## Changes

-   Append the **Exception** object `e` in the ExtensionService `load()` method
