### PR TITLE
fix: throws the full Error message when the Extension load exception

### DIFF
--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -178,7 +178,7 @@ export class ExtensionService implements IExtensionService {
             // Then activate
             this.activate(unloadExtensions);
         } catch (e) {
-            logger.error(ErrorMsg.LoadExtensionFail);
+            logger.error(ErrorMsg.LoadExtensionFail, e);
         }
     }
 


### PR DESCRIPTION
## Description

Throws the `exception` object in the Extension load log.