### PR TITLE
fix: disable click event when action is disabled

### DIFF
--- a/src/workbench/editor/__tests__/action.test.tsx
+++ b/src/workbench/editor/__tests__/action.test.tsx
@@ -5,6 +5,7 @@ import { expectFnCalled } from '@test/utils';
 import '@testing-library/jest-dom';
 
 import EditorAction from '../action';
+import { groupActionItemDisabledClassName } from '../base';
 
 const current: IEditorActionsProps = {
     id: '1',
@@ -70,5 +71,33 @@ describe('The Editor Component', () => {
 
         expect(container.querySelector(`.codicon-warning`)).toBeInTheDocument();
         expect(container.querySelectorAll(`.codicon-warning`)!.length).toBe(8);
+    });
+
+    test('The EditorAction item disabled', () => {
+        const mockAction: IEditorActionsProps[] = Array(8)
+            .fill(1)
+            .map((_, index) => ({
+                id: index.toString(),
+                place: 'outer',
+                icon: 'warning',
+            }));
+        mockAction[0].disabled = true;
+        const mockCallback = jest.fn();
+
+        const { container } = render(
+            <EditorAction
+                isActiveGroup={true}
+                actions={mockAction}
+                onClickActions={jest.fn()}
+            />
+        );
+
+        const liDom = container.querySelector(
+            `.${groupActionItemDisabledClassName}`
+        );
+
+        expect(liDom).not.toBeNull();
+        liDom && fireEvent.click(liDom);
+        expect(mockCallback).not.toBeCalled();
     });
 });

--- a/src/workbench/editor/action.tsx
+++ b/src/workbench/editor/action.tsx
@@ -82,7 +82,9 @@ function EditorAction(props: IEditorActionProps & IEditorController) {
                 outer.map((action) => (
                     <Tooltip key={action.id} overlay={action.title}>
                         <div
-                            onClick={() => handleActionsClick(action)}
+                            onClick={() =>
+                                !action.disabled && handleActionsClick(action)
+                            }
                             className={classNames(
                                 groupActionsItemClassName,
                                 action.disabled &&


### PR DESCRIPTION
## Description

The disable button can also trigger events

Fixes #725

## Changes

Add disable restrictions

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
