### PR TITLE
fix: use the enter character \u21a9

### DIFF
--- a/src/model/keybinding.ts
+++ b/src/model/keybinding.ts
@@ -4,7 +4,7 @@ export const KeyCodeString: Partial<{ [key in KeyCode]: string }> = {
     [KeyCode.Unknown]: '',
     [KeyCode.Backspace]: '⌫',
     [KeyCode.Tab]: '⇥',
-    [KeyCode.Enter]: '↩︎',
+    [KeyCode.Enter]: '↩',
     [KeyCode.PageUp]: '↑',
     [KeyCode.PageDown]: '↓',
     [KeyCode.Digit0]: '0',


### PR DESCRIPTION
## Description

an extra empty string was split due to \ufe0e

Fixes #721

## Changes
```
// old
'↩︎'.split('') // ['↩', '︎'] \u21a9\ufe0e
// new
'↩'.split('') // ['↩'] \u21a9
```
## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
