### PR TITLE
fix: change sort default value 0 to be compatible with Firefox (#722)

### DIFF
--- a/src/workbench/panel/panel.tsx
+++ b/src/workbench/panel/panel.tsx
@@ -28,7 +28,7 @@ export function Panel(props: IPanel & IPanelController) {
         if (a.sortIndex && b.sortIndex) {
             return a.sortIndex - b.sortIndex;
         }
-        return 1;
+        return 0;
     });
 
     return (


### PR DESCRIPTION
## Description

In Firefox, sort is different from other browsers

Fixes #722

## Changes

return 0, leaving the position unchanged

## How Has This Been Tested?

1. use firefox
1. change panal

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
