### PR TITLE
fix: update tab set value

### DIFF
--- a/src/controller/editor.tsx
+++ b/src/controller/editor.tsx
@@ -255,6 +255,10 @@ export class EditorController extends Controller implements IEditorController {
             const tab = current?.tab;
             if (!tab) return;
 
+            const currentEditorUri = current.editorInstance?.getModel()?.uri;
+            const updateEditorUri = editorInstance?.getModel()?.uri;
+            if (currentEditorUri?.path !== updateEditorUri?.path) return;
+
             const newValue = editorInstance.getModel()?.getValue();
             const updatedTab = {
                 ...tab,

--- a/src/services/workbench/__tests__/editorService.test.tsx
+++ b/src/services/workbench/__tests__/editorService.test.tsx
@@ -5,6 +5,7 @@ import { container } from 'tsyringe';
 import { EditorEvent, IEditorTab } from 'mo/model';
 import { expectFnCalled } from '@test/utils';
 import { modules } from 'mo/services/builtinService/const';
+import { editor as MonacoEditor } from 'mo/monaco';
 import { cloneDeep } from 'lodash';
 
 describe('Test EditorService', () => {
@@ -153,6 +154,39 @@ describe('Test EditorService', () => {
         expect(
             editor.getTabById(mockTab.id!, editor.getState().current!.id!)!.name
         ).toBe('updated1');
+    });
+
+    test('Set the editor text for a specific group', () => {
+        const editor = new EditorService();
+        const tabData = {
+            ...mockTab,
+            data: {
+                value: 'tabData',
+            },
+        };
+        editor.open(tabData);
+        const { groups } = editor.getState();
+        if (groups) {
+            const modifyText = 'newValue';
+            const editorData = {
+                value: '',
+            };
+            const editorInstance = {} as MonacoEditor.IStandaloneCodeEditor;
+            editorInstance.getModel = jest.fn(() => {
+                return {
+                    getValue: () => editorData.value,
+                    setValue: (newValue: string) => {
+                        editorData.value = newValue;
+                    },
+                } as MonacoEditor.ITextModel;
+            });
+
+            groups[0].editorInstance = editorInstance;
+            editor.setGroupEditorValue(groups[0], modifyText);
+            expect(groups[0].editorInstance?.getModel()?.getValue()).toBe(
+                modifyText
+            );
+        }
     });
 
     test('Close a tab', () => {


### PR DESCRIPTION
## Description

Can't update editor's value via the updateTab method

Fixes #714

## Changes

-   `editorInstance.onDidChangeModelContent` added comparisons are made through URIs to limit changes to different editors。This is because when you change the contents of the editor with setValue, the onDidChangeModelContent event is triggered, and leaving it unchecked will cause the updateTab method to be called in onDidChangeModelContent, causing a circular call
-   In the updateTab method, check if tab.data.value exists, and call setGroupEditorValue to update the editor text

## How Has This Been Tested?

-   [ ] use updateTab method
```
const handleSubmit = () => {
    molecule.editor.updateTab({
        id: current.tab.id,
       // update the editor's value by str
       data: Object.assign(current.tab.data,{value: str})
    })
}
```
-   [ ] View changes in editor text content

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
