### PR TITLE
fix: add hover style to tab within group (#716)

### DIFF
--- a/src/workbench/editor/style.scss
+++ b/src/workbench/editor/style.scss
@@ -32,6 +32,10 @@
         border-bottom: 1px solid var(--editorGroupHeader-tabsBorder);
         display: flex;
         position: relative;
+
+        #{$tab}__item:hover {
+            background: var(--tab-hoverBackground);
+        }
     }
 
     &__group-tabs {


### PR DESCRIPTION
## Description

Add a tab.hoverBackground variable to control group tabs Floating background color

Fixes # 716

## Changes

## How Has This Been Tested?

https://user-images.githubusercontent.com/46592356/170231008-24940ddd-55f6-4222-9020-c07a14cfda8f.mov


-   [ ] add tab.hoverBackground to the thmem configuration file

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
