### PR TITLE
feat: add getParentNode interface for folderTreeService

### DIFF
--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -1,3 +1,11 @@
+/*
+ * @Author: mumiao mumiao@dtstack.com
+ * @Date: 2022-05-25 14:50:36
+ * @LastEditors: mumiao mumiao@dtstack.com
+ * @LastEditTime: 2022-05-25 18:40:42
+ * @FilePath: /molecule/src/extensions/folderTree/index.tsx
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ */
 import molecule from 'mo';
 import { IExtension } from 'mo/model/extension';
 import {
@@ -10,7 +18,6 @@ export const ExtendsFolderTree: IExtension = {
     name: 'Extends FolderTree',
     activate() {
         molecule.folderTree.onRename((id) => {
-            debugger;
             molecule.folderTree.update({
                 id,
                 isEditable: true,

--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -10,6 +10,7 @@ export const ExtendsFolderTree: IExtension = {
     name: 'Extends FolderTree',
     activate() {
         molecule.folderTree.onRename((id) => {
+            debugger;
             molecule.folderTree.update({
                 id,
                 isEditable: true,

--- a/src/extensions/folderTree/index.tsx
+++ b/src/extensions/folderTree/index.tsx
@@ -1,11 +1,3 @@
-/*
- * @Author: mumiao mumiao@dtstack.com
- * @Date: 2022-05-25 14:50:36
- * @LastEditors: mumiao mumiao@dtstack.com
- * @LastEditTime: 2022-05-25 18:40:42
- * @FilePath: /molecule/src/extensions/folderTree/index.tsx
- * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
- */
 import molecule from 'mo';
 import { IExtension } from 'mo/model/extension';
 import {

--- a/src/services/workbench/__tests__/folderTreeService.test.ts
+++ b/src/services/workbench/__tests__/folderTreeService.test.ts
@@ -494,4 +494,46 @@ describe('Test StatusBarService', () => {
             folderTreeService.emit(FolderTreeEvent.onExpandKeys);
         });
     });
+
+    test('Should support to get the current treeNodes parentNode', () => {
+        const mockRootTree: IFolderTreeNodeProps = {
+            id: '0',
+            name: 'test0',
+            fileType: 'RootFolder',
+            location: 'test0',
+        };
+
+        const mockFolderData = {
+            id: '2',
+            name: 'test1-1',
+            icon: 'test',
+            isLeaf: false,
+            fileType: FileTypes.Folder,
+        };
+
+        const mockFileData = {
+            id: '3',
+            name: 'test1-2',
+            icon: 'test',
+            isLeaf: true,
+            fileType: FileTypes.File,
+        };
+
+        folderTreeService.add(mockRootTree);
+        expect(folderTreeService.get(mockRootTree.id)).toEqual(mockRootTree);
+
+        folderTreeService.add(mockFolderData, mockRootTree.id);
+        expect(folderTreeService.get(mockFolderData.id)).toEqual(
+            mockFolderData
+        );
+
+        folderTreeService.add(mockFileData, mockFolderData.id);
+        expect(folderTreeService.get(mockFileData.id)).toEqual(mockFileData);
+
+        const expectedData = folderTreeService.get(mockFolderData.id);
+
+        expect(folderTreeService.getParentNode(mockFileData.id)).toEqual(
+            expectedData
+        );
+    });
 });

--- a/src/services/workbench/explorer/folderTreeService.ts
+++ b/src/services/workbench/explorer/folderTreeService.ts
@@ -323,7 +323,6 @@ export class FolderTreeService
     }
 
     private getCurrentRootFolderInfo(id: UniqueId) {
-        debugger;
         const currentRootFolder = this.getRootFolderById(id);
         if (!currentRootFolder) {
             return {
@@ -436,7 +435,6 @@ export class FolderTreeService
     }
 
     public update(data: IFolderTreeNodeProps) {
-        debugger;
         const { id, ...restData } = data;
         const { autoSort } = this.state;
         if (!id && id !== 0) throw new Error('Id is required in updating data');

--- a/src/services/workbench/explorer/folderTreeService.ts
+++ b/src/services/workbench/explorer/folderTreeService.ts
@@ -45,6 +45,11 @@ export interface IFolderTreeService extends Component<IFolderTree> {
      */
     get(id: UniqueId): IFolderTreeNodeProps | null;
     /**
+     * get the current treeNode's parentNode
+     * @param id
+     */
+    getParentNode(id: UniqueId): IFolderTreeNodeProps | null;
+    /**
      * Get the context menus for file
      */
     getFileContextMenu: () => IMenuItemProps[];
@@ -227,6 +232,15 @@ export class FolderTreeService
         return this.fileContextMenu;
     }
 
+    public getParentNode(id: UniqueId): IFolderTreeNodeProps | null {
+        const root = this.state.folderTree?.data?.[0];
+        if (!root) return null;
+        const treeHelper = new TreeViewUtil<IFolderTreeNodeProps>(root);
+        const node = treeHelper.getHashMap(id);
+        if (!node) return null;
+        return node.parent ? treeHelper.getNode(node.parent) : null;
+    }
+
     public setFileContextMenu(menus: IMenuItemProps[]) {
         this.fileContextMenu = menus;
     }
@@ -309,6 +323,7 @@ export class FolderTreeService
     }
 
     private getCurrentRootFolderInfo(id: UniqueId) {
+        debugger;
         const currentRootFolder = this.getRootFolderById(id);
         if (!currentRootFolder) {
             return {
@@ -421,6 +436,7 @@ export class FolderTreeService
     }
 
     public update(data: IFolderTreeNodeProps) {
+        debugger;
         const { id, ...restData } = data;
         const { autoSort } = this.state;
         if (!id && id !== 0) throw new Error('Id is required in updating data');

--- a/stories/extensions/test/testPane.tsx
+++ b/stories/extensions/test/testPane.tsx
@@ -412,6 +412,7 @@ PARTITIONED BY (DE STRING) LIFECYCLE 1000;
                     children,
                 })
             );
+
             notice(
                 `The root folder has been added to Explorer and you can switch to Explorer to view it`
             );


### PR DESCRIPTION
## Description
 there is a easier way to get the current treeNode's parentNode?

Fixes #723 

## Changes

Please describe the changes, help the reviewer to read your code.

-   add getParentNode interface for folderTreeService
-   add Unit test for folderTreeService.getParentNode

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
