### PR TITLE
feat:Exposing more props to renderPane for EditorTab（invalid）

### DIFF
--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -3,15 +3,17 @@ import { useRef } from 'react';
 import { findDOMNode } from 'react-dom';
 import { useDrag, useDrop } from 'react-dnd';
 
+import { IEditorGroup } from 'mo/model';
+import type { UniqueId } from 'mo/common/types';
 import {
     classNames,
     getBEMElement,
     getBEMModifier,
     prefixClaName,
 } from 'mo/common/className';
+
 import TabExtra from './tabExtra';
 import { Icon } from '../icon';
-import type { UniqueId } from 'mo/common/types';
 
 export interface ITabEvent {
     onDrag?: (
@@ -49,7 +51,9 @@ export interface ITabProps<T = any, P = any> {
     icon?: string | JSX.Element;
     id: UniqueId;
     name?: string;
-    renderPane?: ((item: P) => React.ReactNode) | React.ReactNode;
+    renderPane?:
+        | ((item: P, tab?: ITabProps, group?: IEditorGroup) => React.ReactNode)
+        | React.ReactNode;
     data?: T;
 }
 

--- a/src/workbench/editor/editor.tsx
+++ b/src/workbench/editor/editor.tsx
@@ -52,6 +52,7 @@ export function Editor(
                 <EditorGroup
                     editorOptions={editorOptions}
                     currentGroup={current!}
+                    group={groups[0]}
                     {...groups[0]}
                     {...getEvents(groups[0].id!)}
                 />
@@ -74,6 +75,7 @@ export function Editor(
                             <EditorGroup
                                 editorOptions={editorOptions}
                                 currentGroup={current!}
+                                group={g}
                                 {...g}
                                 {...getEvents(g.id!)}
                             />

--- a/src/workbench/editor/group.tsx
+++ b/src/workbench/editor/group.tsx
@@ -22,6 +22,7 @@ import { tabItemActiveClassName } from 'mo/components/tabs/tab';
 export interface IEditorGroupProps extends IEditorGroup {
     currentGroup?: IEditorGroup;
     editorOptions?: IEditorOptions;
+    group?: IEditorGroup;
 }
 
 export function EditorGroup(props: IEditorGroupProps & IEditorController) {
@@ -30,6 +31,7 @@ export function EditorGroup(props: IEditorGroupProps & IEditorController) {
         data,
         tab,
         currentGroup,
+        group,
         actions = [],
         menu = [],
         onMoveTab,
@@ -114,7 +116,13 @@ export function EditorGroup(props: IEditorGroupProps & IEditorController) {
                     // Default we use monaco editor, but also you can customize by renderPanel() function or a react element
                     tab?.renderPane ? (
                         typeof tab.renderPane === 'function' ? (
-                            tab.renderPane(tab.data)
+                            tab.renderPane(
+                                {
+                                    ...tab.data,
+                                },
+                                tab,
+                                group
+                            )
                         ) : (
                             tab.renderPane
                         )

--- a/stories/extensions/test/testPane.tsx
+++ b/stories/extensions/test/testPane.tsx
@@ -219,6 +219,30 @@ export type GenericClassDecorator<T> = (target: T) => void;`,
                 });
             }
         };
+        const newPane = function () {
+            const key = shortRandomId();
+            const name = `pane-${key}.ts`;
+            const tabData: IEditorTab = {
+                id: `${key}`,
+                name,
+                icon: 'selection',
+                data: {},
+                breadcrumb: [{ id: `${key}`, name }],
+                renderPane: (tabData, tab, group) => {
+                    console.log(tabData, tab, group);
+                    const style: React.CSSProperties = {
+                        display: 'flex',
+                        width: '100%',
+                        height: '100%',
+                        fontSize: 48,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    };
+                    return <div style={style}>{name}</div>;
+                },
+            };
+            molecule.editor.open(tabData);
+        };
 
         const updateEntryPage = () => {
             const style: React.CSSProperties = {
@@ -427,6 +451,7 @@ PARTITIONED BY (DE STRING) LIFECYCLE 1000;
                         <Button onClick={toggleEditorStatus}>
                             Toggle Editor status
                         </Button>
+                        <Button onClick={newPane}>New Pane</Button>
                         <Button onClick={updateEntryPage}>
                             Update Entry Page
                         </Button>


### PR DESCRIPTION
## Description

exposing more props to renderPane for EditorTab

Fixes #649

## Changes

-   tab.renderPane method arguments add tab and group
-   add renderPane example

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
