### PR TITLE
fix: prevent multiply calls of render function

### DIFF
--- a/src/services/instanceService.tsx
+++ b/src/services/instanceService.tsx
@@ -31,7 +31,7 @@ export default class InstanceService
         defaultLocale: 'en',
     };
 
-    private firstRender = true;
+    private rendered = false;
 
     constructor(config: IConfigProps) {
         super();

--- a/src/services/instanceService.tsx
+++ b/src/services/instanceService.tsx
@@ -31,6 +31,8 @@ export default class InstanceService
         defaultLocale: 'en',
     };
 
+    private firstRender = true;
+
     constructor(config: IConfigProps) {
         super();
         if (config.defaultLocale) {
@@ -59,25 +61,28 @@ export default class InstanceService
     };
 
     public render = (workbench: ReactElement) => {
-        this.emit(InstanceHookKind.beforeInit);
+        if (this.firstRender) {
+            this.emit(InstanceHookKind.beforeInit);
 
-        // get all locales including builtin and custom locales
-        const [languages, others] = molecule.extension.splitLanguagesExts(
-            this._config.extensions
-        );
-        this.initialLocaleService(languages);
+            // get all locales including builtin and custom locales
+            const [languages, others] = molecule.extension.splitLanguagesExts(
+                this._config.extensions
+            );
+            this.initialLocaleService(languages);
 
-        // resolve all controllers, and call `initView` to inject initial values into services
-        Object.keys(controllers).forEach((key) => {
-            const module = controllers[key];
-            const controller = container.resolve<Controller>(module);
-            controller.initView?.();
-        });
+            // resolve all controllers, and call `initView` to inject initial values into services
+            Object.keys(controllers).forEach((key) => {
+                const module = controllers[key];
+                const controller = container.resolve<Controller>(module);
+                controller.initView?.();
+            });
 
-        this.emit(InstanceHookKind.beforeLoad);
-        molecule.extension.load(others);
+            this.emit(InstanceHookKind.beforeLoad);
+            molecule.extension.load(others);
 
-        molecule.monacoService.initWorkspace(molecule.layout.container!);
+            molecule.monacoService.initWorkspace(molecule.layout.container!);
+            this.firstRender = false;
+        }
 
         return workbench;
     };

--- a/src/services/instanceService.tsx
+++ b/src/services/instanceService.tsx
@@ -61,7 +61,7 @@ export default class InstanceService
     };
 
     public render = (workbench: ReactElement) => {
-        if (this.firstRender) {
+        if (!this.rendered) {
             this.emit(InstanceHookKind.beforeInit);
 
             // get all locales including builtin and custom locales

--- a/src/services/instanceService.tsx
+++ b/src/services/instanceService.tsx
@@ -81,7 +81,7 @@ export default class InstanceService
             molecule.extension.load(others);
 
             molecule.monacoService.initWorkspace(molecule.layout.container!);
-            this.firstRender = false;
+            this.rendered = true;
         }
 
         return workbench;


### PR DESCRIPTION
### 简介
- 修复 render 方法会调用多次，导致页面出现重复数据的问题

### 主要原因分析
本地无法复现的原因可能是 react 还是 16.x 的版本导致的，后面需要升级本地的 react 版本。这里的问题是因为 ` const App = () => moInstance.render(<Workbench />);` 如上代码， App 组件因为某种原因重渲染，导致多次执行 moInstance.render 函数

### Related Issues
Closed #767 

### 遗留问题
- 这个问题不论是 yarn web 还是本地的 start 命令启动都无法复现，估计是本地 react 版本问题，后续在做 #688 的时候想办法解决这个问题