### PR TITLE
feat: the text of the optimized tree item is too long

### DIFF
--- a/src/components/tree/style.scss
+++ b/src/components/tree/style.scss
@@ -28,6 +28,9 @@ $treenode-height: 22px;
 
         &__title {
             margin-left: 5px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
             width: 100%;
         }
 


### PR DESCRIPTION
## Description

Text too long, out of width

Fixes #743 

## Changes

Text out of width, showing ellipsis

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
