### PR TITLE
fix: remove invalid Regex in Safari

### DIFF
--- a/src/services/workbench/explorer/folderTreeService.ts
+++ b/src/services/workbench/explorer/folderTreeService.ts
@@ -383,7 +383,7 @@ export class FolderTreeService
         if (currentIndex.node.fileType === FileTypes.File) {
             data.location =
                 currentIndex.node.location?.replace(
-                    /(?<=\/)[^\/]+$/,
+                    /[^\/]+$/,
                     `${data.name}`
                 ) || '';
 


### PR DESCRIPTION
## Description

移除 Safari 中不支持的正则，具体参考：

Fixes #776 

## Changes

-   移除反向肯定预查条件
