### PR TITLE
fix: fix set entry failed at some situations

### DIFF
--- a/src/services/workbench/editorService.ts
+++ b/src/services/workbench/editorService.ts
@@ -50,7 +50,7 @@ export interface IEditorService extends Component<IEditor> {
     /**
      * Specify the Entry page of Workbench
      */
-    setEntry(component: React.ReactNode): void;
+    setEntry(component: JSX.Element): void;
     /**
      * Judge the specific tabs whether opened in Editor view
      * @param tabId The tabId is required


### PR DESCRIPTION
### Intro
- fix set entry failed at some situations

### Changes
It's a typeScript problem indeed. The `React.ReactNode` is different from `JSX.Element`. This function should have used like 
```js
// correct use
molecule.editor.setEntry(<YourComponent />)
```
rather then 
```js
// wrong use
import YourComponent from '../somewhere';
molecule.editor.setEntry(YourComponent)`
```
but TypeScript will not get a error in wrong usage as the wrong type defined.


### Related Issues
Closed #760 