### PR TITLE
fix: prevent updateTab with renderPanel tab

### DIFF
--- a/src/services/workbench/editorService.ts
+++ b/src/services/workbench/editorService.ts
@@ -326,6 +326,7 @@ export class EditorService
                 }
                 if (group.activeTab === tab.id) {
                     isString(editorValue) &&
+                        !tabData?.renderPane &&
                         this.setGroupEditorValue(group, editorValue);
                     updatedTab = Object.assign(group.tab, tab);
                 }
@@ -345,6 +346,7 @@ export class EditorService
 
                 if (group.activeTab === tab.id) {
                     isString(editorValue) &&
+                        !tabData?.renderPane &&
                         this.setGroupEditorValue(group, editorValue);
                     updatedTab = Object.assign(group.tab, tab);
                 }


### PR DESCRIPTION
### 简介
- 修复在某些情况下 updateTab 会更新错误 tab 的内容

### 主要变更
- 当存在非编辑器 tab 的时候，该 tab 调用 updateTab，会导致更新 editorInstance 的内容，从而导致更新错误 tab 的内容

### Related Issues
Closed #780 