### PR TITLE
chore: remove todos

### DIFF
--- a/src/controller/menuBar.ts
+++ b/src/controller/menuBar.ts
@@ -121,11 +121,6 @@ export class MenuBarController
     public readonly onClick = (event: React.MouseEvent, item: IMenuBarItem) => {
         const menuId = item.id || '';
 
-        /**
-         * TODO: Two issues remain to be addressed
-         * 1、the default event is executed twice
-         * 2、we have no way of knowing whether user-defined events are executed internally
-         */
         this.emit(MenuBarEvent.onSelect, menuId);
         this._automation[menuId]?.();
 


### PR DESCRIPTION
### 简介
- 移除不必要的注释

### 主要变更
对该注释内容做如下解释
1. 默认事件渲染两次，无法复现
2. 我们没有必要去探知用户是否执行，换个角度想，其实 subscribe 和 emit 的机制就是单方面的通知。
3. 推测第一条是为了防止同一个事件，Molecule 执行，用户也定义执行，导致执行两次。这种情况除了这里存在，其他地方也存在。用户应该规避这种情况的出现。