### PR TITLE
refactor: optimize modal confirm button style and fix redundacy heade…

### DIFF
--- a/src/components/dialog/__tests__/__snapshots__/actionbutton.test.tsx.snap
+++ b/src/components/dialog/__tests__/__snapshots__/actionbutton.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Test ActionButton Component Match ActionButton Snapshot 1`] = `
 <button
   className="mo-btn mo-btn--normal"
-  closeModal={[MockFunction]}
   onClick={[Function]}
 />
 `;

--- a/src/components/dialog/__tests__/actionbutton.test.tsx
+++ b/src/components/dialog/__tests__/actionbutton.test.tsx
@@ -10,7 +10,7 @@ describe('Test ActionButton Component', () => {
     test('Match ActionButton Snapshot', () => {
         const TEST_FN = jest.fn();
         const component = renderer.create(
-            <ActionButton closeModal={TEST_FN}></ActionButton>
+            <ActionButton close={TEST_FN}></ActionButton>
         );
         const tree = component.toJSON();
 
@@ -24,7 +24,7 @@ describe('Test ActionButton Component', () => {
             <ActionButton
                 data-testid={TEST_ID}
                 actionFn={ACTION_FN}
-                closeModal={MODAL_FN}
+                close={MODAL_FN}
             />
         );
         const button = wrapper.getByTestId(TEST_ID);
@@ -41,7 +41,7 @@ describe('Test ActionButton Component', () => {
             <ActionButton
                 data-testid={TEST_ID}
                 actionFn={ACTION_FN}
-                closeModal={CLOSE_FN}
+                close={CLOSE_FN}
             />
         );
         const button = wrapper.getByTestId(TEST_ID);

--- a/src/components/dialog/__tests__/actionbutton.test.tsx
+++ b/src/components/dialog/__tests__/actionbutton.test.tsx
@@ -4,8 +4,6 @@ import renderer from 'react-test-renderer';
 
 import ActionButton from '../actionButton';
 
-const TEST_ID = 'test-id';
-
 describe('Test ActionButton Component', () => {
     test('Match ActionButton Snapshot', () => {
         const TEST_FN = jest.fn();
@@ -13,39 +11,27 @@ describe('Test ActionButton Component', () => {
             <ActionButton close={TEST_FN}></ActionButton>
         );
         const tree = component.toJSON();
-
         expect(tree).toMatchSnapshot();
     });
 
     test('The ActionButton actionFn', () => {
         const ACTION_FN = jest.fn(() => false);
         const MODAL_FN = jest.fn();
-        const wrapper = render(
-            <ActionButton
-                data-testid={TEST_ID}
-                actionFn={ACTION_FN}
-                close={MODAL_FN}
-            />
+        const { container } = render(
+            <ActionButton actionFn={ACTION_FN} close={MODAL_FN} />
         );
-        const button = wrapper.getByTestId(TEST_ID);
-
-        fireEvent.click(button);
+        fireEvent.click(container.querySelector('.mo-btn')!);
         expect(ACTION_FN).toBeCalled();
         expect(MODAL_FN).toBeCalled();
     });
 
-    test('The ActionButton closeModal', () => {
+    test('The ActionButton close', () => {
         const CLOSE_FN = jest.fn();
         const ACTION_FN = jest.fn(() => Promise.resolve(1));
-        const wrapper = render(
-            <ActionButton
-                data-testid={TEST_ID}
-                actionFn={ACTION_FN}
-                close={CLOSE_FN}
-            />
+        const { container } = render(
+            <ActionButton actionFn={ACTION_FN} close={CLOSE_FN} />
         );
-        const button = wrapper.getByTestId(TEST_ID);
-
+        const button = container.querySelector('.mo-btn')!;
         fireEvent.click(button);
         expect(ACTION_FN).toBeCalled();
     });

--- a/src/components/dialog/__tests__/confirm.test.tsx
+++ b/src/components/dialog/__tests__/confirm.test.tsx
@@ -68,9 +68,6 @@ describe('Test Confirm Component', () => {
             const icon = querySelector('.codicon-warning');
             expect(icon).not.toBeNull();
 
-            const title = querySelector('.mo-modal-title');
-            expect(title?.textContent).toBe(TEST_TITLE);
-
             const confirmTitle = querySelector(`.${textConfirmClassName}`);
             expect(confirmTitle?.textContent).toBe(TEST_TITLE);
 

--- a/src/components/dialog/actionButton.tsx
+++ b/src/components/dialog/actionButton.tsx
@@ -1,9 +1,10 @@
 import React, { useRef } from 'react';
 import { Button, IButtonProps } from 'mo/components/button';
-export interface ActionButtonProps extends IButtonProps {
+export interface ActionButtonProps {
     actionFn?: (...args: any[]) => any | PromiseLike<any>;
     close?: Function;
     buttonProps?: IButtonProps;
+    children?: React.ReactNode;
 }
 
 const ActionButton: React.FC<ActionButtonProps> = (props) => {

--- a/src/components/dialog/actionButton.tsx
+++ b/src/components/dialog/actionButton.tsx
@@ -2,20 +2,21 @@ import React, { useRef } from 'react';
 import { Button, IButtonProps } from 'mo/components/button';
 export interface ActionButtonProps extends IButtonProps {
     actionFn?: (...args: any[]) => any | PromiseLike<any>;
-    closeModal: Function;
+    close?: Function;
+    buttonProps?: IButtonProps;
 }
 
 const ActionButton: React.FC<ActionButtonProps> = (props) => {
     const clickedRef = useRef<boolean>(false);
+    const { close } = props;
 
     const handlePromiseOnOk = (returnValueOfOnOk?: PromiseLike<any>) => {
-        const { closeModal } = props;
         if (!returnValueOfOnOk || !returnValueOfOnOk.then) {
             return;
         }
         returnValueOfOnOk.then(
             (...args: any[]) => {
-                closeModal(...args);
+                close?.(...args);
             },
             (e: Error) => {
                 // eslint-disable-next-line no-console
@@ -26,32 +27,32 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
     };
 
     const onClick = () => {
-        const { actionFn, closeModal } = props;
+        const { actionFn, close } = props;
         if (clickedRef.current) {
             return;
         }
         clickedRef.current = true;
         if (!actionFn) {
-            closeModal();
+            close?.();
             return;
         }
         let returnValueOfOnOk;
         if (actionFn!.length) {
-            returnValueOfOnOk = actionFn(closeModal);
+            returnValueOfOnOk = actionFn(close);
             clickedRef.current = false;
         } else {
             returnValueOfOnOk = actionFn();
             if (!returnValueOfOnOk) {
-                closeModal();
+                close?.();
                 return;
             }
         }
         handlePromiseOnOk(returnValueOfOnOk);
     };
 
-    const { children, ...resetProps } = props;
+    const { children, buttonProps } = props;
     return (
-        <Button onClick={onClick} {...resetProps}>
+        <Button onClick={onClick} {...buttonProps}>
             {children}
         </Button>
     );

--- a/src/components/dialog/confirm.tsx
+++ b/src/components/dialog/confirm.tsx
@@ -46,21 +46,16 @@ export default function confirm(config: IModalFuncProps) {
     function render({ okText, cancelText, ...props }: any) {
         renderUtils(
             <ConfirmDialog
-                {...props}
                 okText={okText}
                 cancelText={cancelText}
+                {...props}
             />,
             div
         );
     }
 
     function close(...args: any[]) {
-        currentConfig = {
-            ...currentConfig,
-            visible: false,
-            afterClose: () => destroy(...args),
-        };
-        render(currentConfig);
+        destroy(...args);
     }
 
     render(currentConfig);

--- a/src/components/dialog/confirm.tsx
+++ b/src/components/dialog/confirm.tsx
@@ -18,7 +18,7 @@ export default function confirm(config: IModalFuncProps) {
     const div = document.createElement('div');
     document.body.appendChild(div);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    let currentConfig = { ...config, close, visible: true } as any;
+    const currentConfig = { ...config, close, visible: true } as any;
 
     function destroy(...args: any[]) {
         const triggerCancel = args.some(

--- a/src/components/dialog/confirmDialog.tsx
+++ b/src/components/dialog/confirmDialog.tsx
@@ -55,7 +55,11 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     );
 
     const cancelButton = okCancel && (
-        <ActionButton actionFn={onCancel} close={close} {...cancelButtonProps}>
+        <ActionButton
+            actionFn={onCancel}
+            close={close}
+            buttonProps={cancelButtonProps}
+        >
             {cancelText}
         </ActionButton>
     );
@@ -102,7 +106,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
                                 <ActionButton
                                     actionFn={onOk}
                                     close={close}
-                                    {...okButtonProps}
+                                    buttonProps={okButtonProps}
                                 >
                                     {okText}
                                 </ActionButton>

--- a/src/components/dialog/confirmDialog.tsx
+++ b/src/components/dialog/confirmDialog.tsx
@@ -29,14 +29,14 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
         onOk,
         close,
         maskStyle,
-        okText = 'delete',
+        okText = 'Ok',
         okButtonProps,
-        cancelText = 'cancel',
+        cancelText = 'Cancel',
         cancelButtonProps,
-        bodyStyle,
-        closable = true,
-        className,
         okCancel,
+        bodyStyle,
+        closable = false,
+        className,
         width = 520,
         style = {},
         mask = true,
@@ -44,11 +44,10 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
         transitionName = 'zoom',
         maskTransitionName = 'fade',
         type,
-        ...resetProps
+        ...restProps
     } = props;
 
     const confirmDescriperClassName = iconConfirmClassName(type);
-
     const classString = classNames(
         confirmClassName,
         confirmDescriperClassName,
@@ -73,16 +72,16 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
                 [centeredConfirmClassName]: !!props.centered,
             })}
             onCancel={() => close({ triggerCancel: true })}
-            title=""
             transitionName={transitionName}
-            footer=""
             maskTransitionName={maskTransitionName}
             mask={mask}
             maskClosable={maskClosable}
             style={style}
             width={width}
             closable={closable}
-            {...resetProps}
+            {...restProps}
+            footer=""
+            title=""
         >
             <div className={containerConfirmClassName} style={bodyStyle}>
                 <div className={contentConfirmClassName}>

--- a/src/components/dialog/confirmDialog.tsx
+++ b/src/components/dialog/confirmDialog.tsx
@@ -44,7 +44,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
         transitionName = 'zoom',
         maskTransitionName = 'fade',
         type,
-        ...restProps
+        visible,
     } = props;
 
     const confirmDescriperClassName = iconConfirmClassName(type);
@@ -55,11 +55,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     );
 
     const cancelButton = okCancel && (
-        <ActionButton
-            actionFn={onCancel}
-            closeModal={close}
-            {...cancelButtonProps}
-        >
+        <ActionButton actionFn={onCancel} close={close} {...cancelButtonProps}>
             {cancelText}
         </ActionButton>
     );
@@ -79,9 +75,10 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
             style={style}
             width={width}
             closable={closable}
-            {...restProps}
             footer=""
             title=""
+            maskStyle={maskStyle}
+            visible={visible}
         >
             <div className={containerConfirmClassName} style={bodyStyle}>
                 <div className={contentConfirmClassName}>
@@ -104,7 +101,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
                             {
                                 <ActionButton
                                     actionFn={onOk}
-                                    closeModal={close}
+                                    close={close}
                                     {...okButtonProps}
                                 >
                                     {okText}

--- a/src/components/dialog/modal.tsx
+++ b/src/components/dialog/modal.tsx
@@ -89,8 +89,8 @@ export const Modal: React.FC<IModalProps> = (props: IModalProps) => {
         centered,
         getContainer,
         closeIcon,
-        cancelText = 'cancel',
-        okText = 'ok',
+        cancelText = 'Cancel',
+        okText = 'Ok',
         ...restProps
     } = props;
 

--- a/src/components/dialog/style.scss
+++ b/src/components/dialog/style.scss
@@ -63,15 +63,16 @@
         background: var(--notificationCenterHeader-background);
         color: var(--notificationCenterHeader-foreground);
         font-size: 24px;
-        padding: 16px 0px;
+        padding: 16px 0;
     }
 
     &-footer {
+        border-radius: 0 0 2px 2px;
         display: flex;
         flex-direction: row;
         justify-content: flex-end;
         padding: 10px 16px;
-        border-radius: 0 0 2px 2px;
+
         .mo-btn {
             margin-left: 8px;
             width: fit-content;
@@ -159,6 +160,7 @@
         flex-direction: row;
         justify-content: flex-end;
         padding: 10px 16px;
+
         .mo-btn {
             margin-left: 8px;
             width: fit-content;

--- a/src/components/dialog/style.scss
+++ b/src/components/dialog/style.scss
@@ -63,16 +63,17 @@
         background: var(--notificationCenterHeader-background);
         color: var(--notificationCenterHeader-foreground);
         font-size: 24px;
-        padding: 16px 0;
+        padding: 16px 0px;
     }
 
     &-footer {
         display: flex;
-        font-size: 13px;
+        flex-direction: row;
         justify-content: flex-end;
-        padding: 20px 10px 10px;
-
-        .mo-botton {
+        padding: 10px 16px;
+        border-radius: 0 0 2px 2px;
+        .mo-btn {
+            margin-left: 8px;
             width: fit-content;
         }
     }
@@ -98,10 +99,10 @@
         &--x {
             display: block;
             font-size: 16px;
-            height: 40px;
+            height: 54px;
             line-height: 40px;
             text-align: center;
-            width: 40px;
+            width: 54px;
         }
     }
 }
@@ -155,7 +156,12 @@
 
     &__btns {
         display: flex;
+        flex-direction: row;
         justify-content: flex-end;
-        padding: 20px 10px 10px;
+        padding: 10px 16px;
+        .mo-btn {
+            margin-left: 8px;
+            width: fit-content;
+        }
     }
 }

--- a/stories/components/17-Dialog.stories.tsx
+++ b/stories/components/17-Dialog.stories.tsx
@@ -24,14 +24,19 @@ stories.add('Basic Usage', () => {
 
     function showConfirm() {
         confirm({
-            title: 'Are you sure you want to permanently delete ?',
-            content: 'This action is irreversible!',
-            cancelButtonProps: { disabled: true },
+            title: 'Tweet us your feedback',
+            content: (
+                <div>
+                    <p>Some contents...</p>
+                    <p>Some contents...</p>
+                    <p>Some contents...</p>
+                </div>
+            ),
             onOk() {
-                console.log('OK');
+                console.log('onOk');
             },
             onCancel() {
-                console.log('Cancel');
+                console.log('onCancel');
             },
         });
     }


### PR DESCRIPTION
#798  

-  启用了  `cancelButtonProps: { disabled: true } `属性，cancel按钮会无法点击
-  优化Modal组件以及 Modal.confirm 使用，**Confirm Button**的样式问题
-  简化 Modal.confirm 展示，去除冗余的**Header**部分
- 解决Modal.confirm 无法关闭的问题