### PR TITLE
fix: fix switch panels between problem and output

### DIFF
--- a/src/services/__tests__/panelService.test.ts
+++ b/src/services/__tests__/panelService.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { container } from 'tsyringe';
 import { PanelService } from '../workbench/panelService';
+import { StandaloneEditor } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 import { PanelEvent } from 'mo/model/workbench/panel';
 import { expectLoggerErrorToBeCalled } from '@test/utils';
 import { modules } from '../builtinService/const';
@@ -12,6 +13,15 @@ const resize = modules.builtInPanelToolboxResize();
 const restore = modules.builtInPanelToolboxReStore();
 
 const panelService = container.resolve(PanelService);
+
+jest.mock(
+    'monaco-editor/esm/vs/editor/standalone/browser/standaloneCodeEditor',
+    () => {
+        return {
+            StandaloneEditor: class {},
+        };
+    }
+);
 
 describe('The PanelService test', () => {
     afterEach(() => {
@@ -128,20 +138,20 @@ describe('The PanelService test', () => {
     });
 
     test('Should NOT clone StandaloneEditor when get the panel', () => {
-        class StandaloneEditor {}
-        const standaloneEditor = new StandaloneEditor();
         panelService.setState({
             data: [
                 {
                     ...paneOutput,
-                    outputEditorInstance: standaloneEditor,
+                    outputEditorInstance: new StandaloneEditor(),
                 } as any,
             ],
         });
 
         const target = panelService.getPanel(paneOutput.id);
         expect(target).toEqual(expect.objectContaining(paneOutput));
-        expect((target as any).outputEditorInstance).toBe(standaloneEditor);
+        expect((target as any).outputEditorInstance).toBeInstanceOf(
+            StandaloneEditor
+        );
     });
 
     test('Should support to active a exist panel', () => {

--- a/src/services/workbench/panelService.ts
+++ b/src/services/workbench/panelService.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { singleton, container } from 'tsyringe';
 import { editor as MonacoEditor } from 'monaco-editor';
+import { StandaloneEditor } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 import { cloneDeepWith, cloneDeep } from 'lodash';
 import pickBy from 'lodash/pickBy';
 import { Component } from 'mo/react';
@@ -194,7 +195,7 @@ export class PanelService extends Component<IPanel> implements IPanelService {
             if (
                 value &&
                 typeof value === 'object' &&
-                value.constructor.name === 'StandaloneEditor'
+                value instanceof StandaloneEditor
             ) {
                 return value;
             }


### PR DESCRIPTION
### 简介
- 修复面板切换在某些情况下会报错导致无法切换的问题


### 主要变更
- 出现问题的是地方是深拷贝的时候，需要跳过 StandaloneEditor 类。本来是通过 constructor.name 来判断，但是在 terser 之后会导致构造类的 name 发生改变，所以改成 instanceof 判断


### Related Issues
Closed #812 