### PR TITLE
build: remove babel-loader for monaco-editor

### DIFF
--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -35,10 +35,6 @@ module.exports = {
                 test: /\.scss$/,
                 use: ['style-loader', 'css-loader', 'sass-loader'],
             },
-            {
-                test: /monaco-editor\/.*\.js/,
-                loader: 'babel-loader',
-            },
         ],
     },
     plugins: [


### PR DESCRIPTION
### 简介
- 移除 monaco-editor 的相关 rule
- 适配 pnpm@7