### PR TITLE
fix: can't prevent close tab with confirm

### DIFF
--- a/src/controller/editor.tsx
+++ b/src/controller/editor.tsx
@@ -142,29 +142,24 @@ export class EditorController extends Controller implements IEditorController {
     };
 
     public onCloseAll = (groupId: UniqueId) => {
-        this.editorService.closeAll(groupId);
         this.emit(EditorEvent.OnCloseAll, groupId);
     };
 
     public onCloseTab = (tabId?: UniqueId, groupId?: UniqueId) => {
         if (tabId && groupId) {
-            this.editorService.closeTab(tabId, groupId);
             this.emit(EditorEvent.OnCloseTab, tabId, groupId);
         }
     };
 
     public onCloseToRight = (tabItem: IEditorTab, groupId: UniqueId) => {
-        this.editorService.closeToRight(tabItem, groupId);
         this.emit(EditorEvent.OnCloseToRight, tabItem, groupId);
     };
 
     public onCloseToLeft = (tabItem: IEditorTab, groupId: UniqueId) => {
-        this.editorService.closeToLeft(tabItem, groupId);
         this.emit(EditorEvent.OnCloseToLeft, tabItem, groupId);
     };
 
     public onCloseOther = (tabItem: IEditorTab, groupId: UniqueId) => {
-        this.editorService.closeOther(tabItem, groupId);
         this.emit(EditorEvent.OnCloseOther, tabItem, groupId);
     };
 

--- a/src/extensions/editor/index.ts
+++ b/src/extensions/editor/index.ts
@@ -1,0 +1,39 @@
+import molecule from 'mo';
+import { IExtension } from 'mo/model/extension';
+
+export const ExtendsEditor: IExtension = {
+    id: 'ExtendsEditor',
+    name: 'Extends Editor',
+    dispose() {},
+    activate() {
+        molecule.editor.onCloseTab((tabId, groupId) => {
+            if (tabId !== undefined && groupId !== undefined) {
+                molecule.editor.closeTab(tabId, groupId);
+            }
+        });
+
+        molecule.editor.onCloseAll((groupId) => {
+            if (groupId !== undefined) {
+                molecule.editor.closeAll(groupId);
+            }
+        });
+
+        molecule.editor.onCloseOther((tabItem, groupId) => {
+            if (tabItem && groupId !== undefined) {
+                molecule.editor.closeOther(tabItem, groupId);
+            }
+        });
+
+        molecule.editor.onCloseToLeft((tabItem, groupId) => {
+            if (tabItem && groupId !== undefined) {
+                molecule.editor.closeToLeft(tabItem, groupId);
+            }
+        });
+
+        molecule.editor.onCloseToRight((tabItem, groupId) => {
+            if (tabItem && groupId !== undefined) {
+                molecule.editor.closeToRight(tabItem, groupId);
+            }
+        });
+    },
+};

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -10,12 +10,14 @@ import { monokaiColorThemeExtension } from './theme-monokai';
 import { paleNightColorThemeExtension } from './vscode-palenight-theme';
 import { webStormIntelliJExtension } from './vscode-intellij-darcula-theme-master';
 import { githubPlusExtension } from './github-plus-theme-master';
+import { ExtendsEditor } from './editor';
 
 /**
  * Default extensions
  */
 export const defaultExtensions = [
     ExtendsPanel,
+    ExtendsEditor,
     ExtendsActivityBar,
     ExtendsExplorer,
     ExtendsEditorTree,

--- a/stories/extensions/test/index.tsx
+++ b/stories/extensions/test/index.tsx
@@ -5,6 +5,8 @@ import { FileTypes, IExtension, TreeNodeModel } from 'mo/model';
 
 import TestPane from './testPane';
 import { randomId } from 'mo/common/utils';
+import { ListenerEventContext } from 'mo/common/event';
+import { UniqueId } from 'mo/common/types';
 
 export const ExtendsTestPane: IExtension = {
     id: 'ExtendsTestPane',
@@ -179,5 +181,25 @@ export const ExtendsTestPane: IExtension = {
         molecule.explorer.onCollapseAllFolders(() => {
             molecule.folderTree.setExpandKeys([]);
         });
+
+        function closeTabHandler(
+            this: ListenerEventContext,
+            tabId: UniqueId,
+            groupId?: UniqueId
+        ) {
+            this.stopDelivery();
+            molecule.component.Modal.confirm({
+                title: '确认关闭 tab 吗',
+                content: '关闭后数据会丢失',
+                onOk() {
+                    if (groupId !== undefined && tabId !== undefined) {
+                        molecule.editor.closeTab(tabId, groupId);
+                    }
+                },
+                onCancel() {},
+            });
+        }
+        molecule.editorTree.onClose(closeTabHandler);
+        molecule.editor.onCloseTab(closeTabHandler);
     },
 };


### PR DESCRIPTION
### 简介
- 修复无法在关闭 tab 之前插入 confirm 的问题

### 主要变更
把 controller 里的默认行为放到 default extensions 里，支持用户通过 event 阻止事件链传递