### PR TITLE
refactor: folderTree'input support default contextmenu

### DIFF
--- a/src/components/contextMenu/index.tsx
+++ b/src/components/contextMenu/index.tsx
@@ -23,14 +23,17 @@ export function useContextMenu(
     });
 
     const onContextMenu = (e: MouseEvent) => {
-        e.preventDefault();
-        contextView!.show(
-            {
-                x: e.clientX,
-                y: e.clientY,
-            },
-            render
-        );
+        // ONLY works over the anchor ele
+        if (e.target === e.currentTarget) {
+            e.preventDefault();
+            contextView!.show(
+                {
+                    x: e.clientX,
+                    y: e.clientY,
+                },
+                render
+            );
+        }
     };
 
     anchor.addEventListener('contextmenu', onContextMenu);

--- a/src/components/tree/index.tsx
+++ b/src/components/tree/index.tsx
@@ -180,7 +180,6 @@ const TreeView = ({
         e: React.MouseEvent<HTMLDivElement, MouseEvent>,
         info: ITreeNodeItemProps
     ) => {
-        e.preventDefault();
         e.stopPropagation();
         onRightClick?.(e, info);
     };

--- a/src/workbench/problems/__tests__/paneView.test.tsx
+++ b/src/workbench/problems/__tests__/paneView.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import {
+    cleanup,
+    createEvent,
+    fireEvent,
+    render,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ProblemsPaneView from '../paneView';
 import { MarkerSeverity } from 'mo/model';
@@ -112,5 +117,21 @@ describe('The PaneView Component', () => {
             'No problems have been detected in the workspace.'
         );
         expect(tips).toBeInTheDocument();
+    });
+
+    test('Should prevent default on contextMenu', () => {
+        const { container } = render(<ProblemsPaneView {...mockRootData} />);
+
+        const dom = container.querySelector(
+            `div[data-key="${mockProblemFile.id}"]`
+        );
+        expect(dom).toBeInTheDocument();
+
+        const myEvent = createEvent.contextMenu(dom!);
+        myEvent.preventDefault = jest.fn();
+
+        fireEvent(dom!, myEvent);
+
+        expect(myEvent.preventDefault as jest.Mock).toBeCalled();
     });
 });

--- a/src/workbench/problems/paneView/index.tsx
+++ b/src/workbench/problems/paneView/index.tsx
@@ -71,6 +71,7 @@ function ProblemsPaneView(props: IProblems) {
                         );
                     }}
                     onSelect={onSelect}
+                    onRightClick={(e) => e.preventDefault()}
                 />
             </div>
         </Scrollbar>

--- a/src/workbench/sidebar/__tests__/searchPanel.test.tsx
+++ b/src/workbench/sidebar/__tests__/searchPanel.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import {
+    cleanup,
+    createEvent,
+    fireEvent,
+    render,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { expectFnCalled } from '@test/utils';
 import { SearchPanel } from '../search';
@@ -218,5 +223,27 @@ describe('The SearchPanel Component', () => {
         );
 
         expect(getByTitle(resultTree[0].name)).toBeInTheDocument();
+    });
+
+    test("Should prevent default on tree's contextMenu event handler", () => {
+        expectFnCalled((mockFn) => {
+            const { container } = render(
+                <SearchPanel
+                    value="test"
+                    result={mockResult}
+                    getSearchIndex={() => 0}
+                />
+            );
+
+            const target = mockResult[1];
+            const dom = container.querySelector(
+                `.${defaultTreeNodeClassName}[data-key="${target.id}"]`
+            )!;
+
+            const myEvent = createEvent.contextMenu(dom!);
+            myEvent.preventDefault = mockFn;
+
+            fireEvent(dom!, myEvent);
+        });
     });
 });

--- a/src/workbench/sidebar/explore/folderTree.tsx
+++ b/src/workbench/sidebar/explore/folderTree.tsx
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import React, { memo, useRef, useEffect, useLayoutEffect } from 'react';
 import { IFolderTree, IFolderTreeNodeProps } from 'mo/model';
 import { select, getEventPosition } from 'mo/common/dom';
-import Tree from 'mo/components/tree';
+import Tree, { ITreeProps } from 'mo/components/tree';
 import { IMenuItemProps, Menu } from 'mo/components/menu';
 import { Button } from 'mo/components/button';
 import type { IFolderTreeController } from 'mo/controller/explorer/folderTree';
@@ -126,17 +126,20 @@ const FolderTree: React.FunctionComponent<IFolderTreeProps> = (props) => {
         contextView?.hide();
     };
 
-    const handleRightClick = (event, data) => {
-        const menuItems = onRightClick?.(data) || [];
+    const handleRightClick: ITreeProps['onRightClick'] = (event, data) => {
+        if ((event.target as HTMLElement).nodeName !== 'INPUT') {
+            event.preventDefault();
+            const menuItems = onRightClick?.(data) || [];
 
-        menuItems.length &&
-            contextView?.show(getEventPosition(event), () => (
-                <Menu
-                    role="menu"
-                    onClick={(_, item) => handleMenuClick(item!, data)}
-                    data={menuItems}
-                />
-            ));
+            menuItems.length &&
+                contextView?.show(getEventPosition(event), () => (
+                    <Menu
+                        role="menu"
+                        onClick={(_, item) => handleMenuClick(item!, data)}
+                        data={menuItems}
+                    />
+                ));
+        }
     };
 
     const handleUpdateFile = (

--- a/src/workbench/sidebar/search/searchTree.tsx
+++ b/src/workbench/sidebar/search/searchTree.tsx
@@ -14,6 +14,7 @@ const SearchTree = (props: SearchTreeProps) => {
             data={data}
             renderTitle={renderTitle}
             onSelect={onSelect}
+            onRightClick={(e) => e.preventDefault()}
         />
     );
 };


### PR DESCRIPTION
### 简介
- 修复 folderTree 的 Input 右键菜单的问题

### 主要变更
前：
![image](https://user-images.githubusercontent.com/18719701/210506839-7582a220-04c7-441d-beda-2e522b36235a.png)
后：
![image](https://user-images.githubusercontent.com/18719701/210506949-7ffb465b-d4cd-4136-b8c5-3de0f491711c.png)


确保 Input 的 onContextMenu 不会被 prevenDefault，同时需要 useContextMenu 不会被子元素触发


### Related Issues
Closed #837 