### PR TITLE
feat(folderTree): support to show active indent line

### DIFF
--- a/src/client/components/tree/index.scss
+++ b/src/client/components/tree/index.scss
@@ -7,11 +7,18 @@ $indent: BEMElement($container, 'indent');
 $guide: BEMElement($indent, 'guide');
 
 $active: BEMModifier($treeNode, 'active');
+$activeGuide: BEMModifier($guide, 'active');
 
 $treenode-height: 22px;
 
 .#{$container} {
     font-size: 13px;
+
+    &:hover {
+        .#{$indent} .#{$guide} {
+            border-left-color: var(--tree-inactiveIndentGuidesStroke);
+        }
+    }
 
     .#{$treeNode} {
         align-items: center;
@@ -45,13 +52,18 @@ $treenode-height: 22px;
     .#{$indent} {
         display: flex;
         height: 100%;
-        margin-right: 2px;
+        margin-right: -4px;
 
         .#{$guide} {
-            border-left: 1px solid var(--tree-indentGuidesStroke);
+            border-left: 1px solid transparent;
             display: inline-block;
             height: 100%;
             margin-left: 7px;
+            transition: border-color 0.1s linear;
+
+            &.#{$activeGuide} {
+                border-left-color: var(--tree-indentGuidesStroke);
+            }
         }
     }
 
@@ -70,4 +82,5 @@ $treenode-height: 22px;
     title: $title;
     guide: $guide;
     active: $active;
+    activeGuide: $activeGuide;
 }

--- a/src/client/components/tree/index.tsx
+++ b/src/client/components/tree/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { classNames } from 'mo/client/classNames';
@@ -10,6 +10,8 @@ import TreeNode from './treeNode';
 import variables from './index.scss';
 
 type ITreeNodeItemProps = TreeNodeModel<any>;
+
+const INDENT = 8;
 
 export interface ITreeProps {
     data?: ITreeNodeItemProps[];
@@ -48,37 +50,37 @@ export default function Tree({
     onDrop,
 }: ITreeProps) {
     const wrapper = useRef<HTMLDivElement>(null);
-    const pathMap: Record<UniqueId, UniqueId[]> = {};
 
-    let activeFolderId: UniqueId;
-    let activeIndent: number;
+    const pathMap = useMemo(() => {
+        const map: Record<UniqueId, UniqueId[]> = {};
+        const updateMap = (nodes: ITreeNodeItemProps[], paths: UniqueId[]) => {
+            nodes.forEach((node) => {
+                map[node.id] = paths;
+                if (node.children) {
+                    updateMap(node.children, [...paths, node.id]);
+                }
+            });
+        };
+        updateMap(data, []);
+        return map;
+    }, [data]);
 
-    const updatePathMap = (data: ITreeNodeItemProps[], paths: UniqueId[], indent: number) => {
-        data.forEach((item) => {
-            pathMap[item.id] = paths;
-            if (item.id === activeKey) {
-                activeIndent = indent;
+    const { activeFolderId, activeIndent } = useMemo(() => {
+        let activeFolderId: UniqueId = '';
+        let activeIndent = 0;
+
+        if (activeKey !== undefined) {
+            const paths = pathMap[activeKey] || [];
+            if (expandedKeys.includes(activeKey)) {
+                activeFolderId = activeKey;
+                activeIndent = paths.length + 1;
+            } else {
+                activeFolderId = paths[paths.length - 1];
+                activeIndent = paths.length;
             }
-            if (item.children?.length) {
-                updatePathMap(item.children, [...paths, item.id], indent + 1);
-            }
-        });
-    };
-
-    const updateActiveFolderId = () => {
-        if (activeKey === undefined) return;
-        const paths = pathMap[activeKey] || [];
-
-        if (expandedKeys.includes(activeKey)) {
-            activeFolderId = activeKey;
-            activeIndent = activeIndent + 1;
-        } else {
-            activeFolderId = paths[paths.length - 1];
         }
-    };
-
-    updatePathMap(data, [], 0);
-    updateActiveFolderId();
+        return { activeFolderId, activeIndent };
+    }, [activeKey, expandedKeys, pathMap]);
 
     const handleNodeClick = (node: ITreeNodeItemProps, e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         e.stopPropagation();
@@ -92,6 +94,15 @@ export default function Tree({
         return <Icon type={isExpand ? 'chevron-down' : 'chevron-right'} />;
     };
 
+    const renderIndent = (indent: number, isAncestorActive: boolean) => (
+        <div className={variables.indent} style={{ width: INDENT * indent }}>
+            {new Array(indent).fill('').map((_, index) => {
+                const isActive = isAncestorActive && activeIndent === index + 1;
+                return <div key={index} className={classNames(variables.guide, isActive && variables.activeGuide)} />;
+            })}
+        </div>
+    );
+
     const renderTreeNode = (data: ITreeNodeItemProps[], indent: number) => {
         return data.map((item, index) => {
             const uuid = item.id;
@@ -100,15 +111,13 @@ export default function Tree({
             const isActive = activeKey === uuid;
 
             const IconComponent = typeof item.icon === 'string' ? <Icon type={item.icon} /> : item.icon;
-            const nodeOffset = item.fileType === FileTypes.Folder ? 0 : 16;
+            const nodeOffset = item.fileType === FileTypes.Folder ? 0 : INDENT * 2;
             const paths = pathMap[item.id] || [];
             const isAncestorActive = paths.includes(activeFolderId);
 
             const currentNode = (
                 <TreeNode
                     key={`${uuid}-${indent}`}
-                    isAncestorActive={isAncestorActive}
-                    activeIndent={activeIndent}
                     draggable={draggable}
                     data={item}
                     indent={indent}
@@ -125,6 +134,7 @@ export default function Tree({
                         </>
                     )}
                     renderTitle={() => renderTitle?.(item, index, item.fileType === FileTypes.File) || item.name}
+                    renderIndent={() => renderIndent(indent, isAncestorActive)}
                     onClick={(e) => handleNodeClick(item, e)}
                     onKeyDown={(e) => onKeyDown?.(e, item)}
                     onContextMenu={onContextMenu}

--- a/src/client/components/tree/treeNode.tsx
+++ b/src/client/components/tree/treeNode.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
+import { classNames } from 'mo/client/classNames';
 import { ContextMenuHandler } from 'mo/types';
 import { TreeNodeModel } from 'mo/utils/tree';
 
@@ -13,6 +14,8 @@ export interface ITreeNodeProps {
     indent: number;
     className?: string;
     draggable?: boolean;
+    isAncestorActive?: boolean;
+    activeIndent?: number;
     renderIcon: () => JSX.Element | null;
     renderTitle: () => React.ReactNode;
     onClick?: React.MouseEventHandler<HTMLDivElement>;
@@ -30,6 +33,8 @@ export default ({
     indent,
     className,
     draggable,
+    isAncestorActive,
+    activeIndent,
     renderIcon,
     renderTitle,
     onClick,
@@ -91,9 +96,12 @@ export default ({
             onContextMenu={(e) => onContextMenu?.({ x: e.pageX, y: e.pageY }, data)}
         >
             <div className={variables.indent} style={{ width: INDENT * indent }}>
-                {new Array(indent).fill('').map((_, index) => (
-                    <div key={index} className={variables.guide} />
-                ))}
+                {new Array(indent).fill('').map((_, index) => {
+                    const isActive = isAncestorActive && activeIndent === index + 1;
+                    return (
+                        <div key={index} className={classNames(variables.guide, isActive && variables.activeGuide)} />
+                    );
+                })}
             </div>
             {renderIcon()}
             <div className={variables.title}>{title}</div>

--- a/src/client/components/tree/treeNode.tsx
+++ b/src/client/components/tree/treeNode.tsx
@@ -1,6 +1,5 @@
 import { useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
-import { classNames } from 'mo/client/classNames';
 import { ContextMenuHandler } from 'mo/types';
 import { TreeNodeModel } from 'mo/utils/tree';
 
@@ -14,10 +13,9 @@ export interface ITreeNodeProps {
     indent: number;
     className?: string;
     draggable?: boolean;
-    isAncestorActive?: boolean;
-    activeIndent?: number;
     renderIcon: () => JSX.Element | null;
     renderTitle: () => React.ReactNode;
+    renderIndent: () => JSX.Element;
     onClick?: React.MouseEventHandler<HTMLDivElement>;
     onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
     onContextMenu?: ContextMenuHandler<[treeNode: ITreeNodeItemProps]>;
@@ -26,17 +24,15 @@ export interface ITreeNodeProps {
     onDragEnd?: (data: ITreeNodeItemProps) => void;
     onDrop?: (source: ITreeNodeItemProps, traget: ITreeNodeItemProps) => void;
 }
-const INDENT = 8;
 
 export default ({
     data,
     indent,
     className,
     draggable,
-    isAncestorActive,
-    activeIndent,
     renderIcon,
     renderTitle,
+    renderIndent,
     onClick,
     onDragStart,
     onDragOver,
@@ -95,14 +91,7 @@ export default ({
             onKeyDown={handleKeyDown}
             onContextMenu={(e) => onContextMenu?.({ x: e.pageX, y: e.pageY }, data)}
         >
-            <div className={variables.indent} style={{ width: INDENT * indent }}>
-                {new Array(indent).fill('').map((_, index) => {
-                    const isActive = isAncestorActive && activeIndent === index + 1;
-                    return (
-                        <div key={index} className={classNames(variables.guide, isActive && variables.activeGuide)} />
-                    );
-                })}
-            </div>
+            {renderIndent()}
             {renderIcon()}
             <div className={variables.title}>{title}</div>
         </Prevent>

--- a/src/extensions/folderTree/index.ts
+++ b/src/extensions/folderTree/index.ts
@@ -8,9 +8,10 @@ export const ExtendsFolderTree: IExtension = {
     name: 'Extend The Default Folder Tree',
     activate: function (molecule): void {
         molecule.folderTree.onSelect((treeNode) => {
+            molecule.folderTree.setCurrent(treeNode.id);
+
             if (treeNode.fileType === FileTypes.File) {
                 molecule.folderTree.setEditing();
-                molecule.folderTree.setCurrent(treeNode.id);
             } else {
                 molecule.folderTree.toggleExpanded(treeNode.id);
 

--- a/src/models/folderTree.ts
+++ b/src/models/folderTree.ts
@@ -17,6 +17,7 @@ export enum FolderTreeEvent {
     onDragStart = 'folderTree.onDragStart',
     onDragOver = 'folderTree.onDragOver',
     onDragEnd = 'folderTree.onDragEnd',
+    onCurrentChange = 'folderTree.onCurrentChange',
 }
 
 export class FolderTreeModel {

--- a/src/services/folderTree.ts
+++ b/src/services/folderTree.ts
@@ -119,6 +119,7 @@ export class FolderTreeService extends BaseService<FolderTreeModel> {
     }
 
     public setCurrent(id?: UniqueId) {
+        this.emit(FolderTreeEvent.onCurrentChange, this.getCurrent(), id);
         this.dispatch((draft) => {
             draft.current = id;
         });
@@ -242,4 +243,8 @@ export class FolderTreeService extends BaseService<FolderTreeModel> {
     public onDrop = <T = any>(callback: (source: TreeNodeModel<T>, target: TreeNodeModel<T>) => void) => {
         this.subscribe(FolderTreeEvent.onDrop, callback);
     };
+
+    public onCurrentChange(callback: (prev: UniqueId, next: UniqueId) => void) {
+        this.subscribe(FolderTreeEvent.onCurrentChange, callback);
+    }
 }


### PR DESCRIPTION
## 简介

优化folderTree节点的缩进
优化folderTree缩进线条的交互与展示
folderTree添加onCurrentChange事件

## 变更

优化前：
![old](https://github.com/DTStack/molecule/assets/26963012/ed4bb2da-527b-42d9-a3d1-8ca2000c7497)

优化后：
![new](https://github.com/DTStack/molecule/assets/26963012/12142b4e-ee7a-46e3-9779-cef89e8f0b70)

### 缩进线条激活逻辑说明
- 激活节点为文件（叶子节点）：
所有兄弟节点的最后一个缩进线条，以及兄弟节点下所有后代节点的同一缩进位置线条激活

- 激活节点为文件夹：
文件夹展开时，所有后代节点的同一缩进位置线条激活
文件夹关闭时，当前文件夹的父节点下所有后代节点的同一缩进位置线条激活