### PR TITLE
修改 instanceService 以支持可自定义外层组件

### DIFF
--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -387,5 +387,6 @@ export class InstanceService extends GlobalEvent implements IInstanceServiceProp
         this.root?.unmount();
         this.root = undefined;
         this.predict = undefined;
+		this.wrapper = undefined;
     }
 }

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -387,6 +387,6 @@ export class InstanceService extends GlobalEvent implements IInstanceServiceProp
         this.root?.unmount();
         this.root = undefined;
         this.predict = undefined;
-		this.wrapper = undefined;
+        this.wrapper = undefined;
     }
 }


### PR DESCRIPTION
## Description

需求：
很多UI组件都要在最外层提供一个Context以实现配置、主题等数据的共享，比如 antd 的 ConfigProvider。 molecule 会在 instance.create 方法中创建一个新的 react rootelement，如果想在插件页面中使用第三方UI组件库，需要每一个 JSX 单独配置 Provider，不方便共享配置。

本PR功能：
为 instance.create 增加一个参数 wrapper，用户可以自定义包裹 WorkBench的外层组件。
Fixes # (issue)

## Changes

-   services/instance.ts 的 create 函数添加了一个参数 wrapper: RenderFunction<ReactNode>

## Usage
```typescript
import { ReactNode, useEffect, useRef } from 'react';
import { create } from '@dtinsight/molecule';
import { MantineProvider } from '@mantine/core'

const instance = create({
    extensions: import('./extensions/TestExtension').then(({ TestExtension }) => [TestExtension]),
    defaultLocale: 'zh-CN',
    defaultColorTheme: 'Default Light+',
    onigurumPath: '/wasm/onig.wasm',
});

export default function App() {
    const container = useRef<HTMLDivElement>(null);
    useEffect(() => {
        //                                👇这里
        instance.render(container.current, (content: ReactNode) => <MantineProvider>{content}</MantineProvider>);

        return () => {
            instance.dispose();
        };
    }, []);
    return <div ref={container} />;
}

```

## Results
![image](https://github.com/DTStack/molecule/assets/1853799/8c41503e-b934-4a8f-bb8e-bb77a2941a2e)
