### PR TITLE
Feat 2.x update colors

### DIFF
--- a/app/src/components/testPane.css
+++ b/app/src/components/testPane.css
@@ -6,3 +6,13 @@ h2 {
     padding: 6px 0;
     user-select: none;
 }
+
+.test-pane {
+    padding: 0 16px 16px;
+}
+
+.test-pane .mo-btn {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/app/src/components/testPane.tsx
+++ b/app/src/components/testPane.tsx
@@ -421,6 +421,32 @@ export default function TestPane({ context: molecule }: { context: IMoleculeCont
         molecule.auxiliaryBar.setCurrent(id);
     };
 
+    const updateThemeColors = () => {
+        molecule.colorTheme.updateColors([
+            {
+                id: 'Default Dark+',
+                colors: {
+                    'sideBar.background': '#555555',
+                    'activityBar.background': '#666666',
+                },
+            },
+            {
+                id: 'Default Light+',
+                colors: {
+                    'sideBar.background': '#C3C3C3',
+                    'activityBar.background': '#5c5c5c',
+                },
+            },
+            {
+                id: 'Default High Contrast',
+                colors: {
+                    'sideBar.background': '#333333',
+                    'activityBar.background': '#333333',
+                },
+            },
+        ]);
+    };
+
     useEffect(() => {
         return () => {
             if (timeout) {
@@ -431,7 +457,7 @@ export default function TestPane({ context: molecule }: { context: IMoleculeCont
 
     return (
         <components.ScrollBar isShowShadow>
-            <div style={{ padding: '0 16px' }}>
+            <div className="test-pane">
                 <h2>Editor:</h2>
                 <div style={{ gap: 5, display: 'grid' }}>
                     <components.Button block onClick={newEditor}>
@@ -586,6 +612,12 @@ export default function TestPane({ context: molecule }: { context: IMoleculeCont
                 <div style={{ gap: 5, display: 'grid' }}>
                     <components.Button block onClick={updateLocale}>
                         Switch locale between English and Chinese
+                    </components.Button>
+                </div>
+                <h2>ColorTheme:</h2>
+                <div style={{ gap: 5, display: 'grid' }}>
+                    <components.Button block onClick={updateThemeColors}>
+                        Update theme colors
                     </components.Button>
                 </div>
             </div>

--- a/src/services/colorTheme.ts
+++ b/src/services/colorTheme.ts
@@ -126,15 +126,32 @@ export class ColorThemeService extends BaseService<ColorThemeModel> {
             const target = draft.data.find(searchById(typeof item === 'object' ? item.id : item));
             if (target) {
                 Object.assign(target, typeof item === 'object' ? item : predict?.(target));
-                // If current theme be updated, then reload it
-                if (target.id === this.getState().current) {
-                    this.applyColorTheme(target.id);
-                }
             }
         });
+        // If current theme be updated, then reload it
         if (this.getCurrent() === (typeof item === 'object' ? item.id : item)) {
             this.applyColorTheme(this.getCurrent());
         }
+    }
+
+    public updateColors(colorItems: Arraylize<Required<Pick<IColorTheme, 'id' | 'colors'>>>): void;
+    public updateColors(id: UniqueId, colors: IColorTheme['colors']): void;
+    public updateColors(
+        items: UniqueId | Arraylize<Required<Pick<IColorTheme, 'id' | 'colors'>>>,
+        colors?: IColorTheme['colors']
+    ) {
+        arraylize(items).forEach((item) => {
+            this.dispatch((draft) => {
+                const target = draft.data.find(searchById(typeof item === 'object' ? item.id : item));
+                if (target) {
+                    target.colors = Object.assign({}, target.colors, typeof item === 'object' ? item.colors : colors);
+                }
+            });
+            // If current theme be updated, then reload it
+            if (this.getCurrent() === (typeof item === 'object' ? item.id : item)) {
+                this.applyColorTheme(this.getCurrent());
+            }
+        });
     }
 
     public get(id: UniqueId) {


### PR DESCRIPTION
# 简介
- ColorTheme 添加 updateColors 方法以支持直接更新 colors
- 移除在 dispatch 回调函数内更新主题的操作（在 dispatch 回调函数内拿到的数据还是旧的，所以更新不会生效）
- testPane 添加 updateColors demo & 样式优化