### PR TITLE
fix: search supports Chinese input

### DIFF
--- a/src/client/slots/search/index.tsx
+++ b/src/client/slots/search/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useTransition } from 'react';
 import { classNames } from 'mo/client/classNames';
 import { Input, ScrollBar, Text, Tree } from 'mo/client/components';
 import { useConnector, useLocale } from 'mo/client/hooks';
@@ -18,9 +18,15 @@ export default function Search({ onChange, onSearch, onEnter, onSelect }: ISearc
 
     const placeholder = localize(builtin.constants.SIDEBAR_ITEM_SEARCH, 'Search');
 
+    const [_, startTransition] = useTransition();
+
     const handleChange = (value: string) => {
-        onChange?.(value);
-        onSearch?.(value);
+        // Lower the priority of the update operation to prevent the input state from being interrupted
+        // and ensure that Chinese can be input.
+        startTransition(() => {
+            onChange?.(value);
+            onSearch?.(value);
+        });
     };
 
     const renderTip = () => {


### PR DESCRIPTION
## 简介
修复 search 不支持输入中文问题

### 问题原因
1. 输入中文时，输入法会分阶段更新 DOM 的 value，如果被打断，会导致无法输入中文。
2. 受控 input 组件期望在 onChange 事件中同步更新 value，但是订阅到 store 上的监听函数，在 store 发生变化时通过 window.queueMicrotask 异步执行，导致 react 状态滞后于输入法的更新，使得中文输入状态被打断。

### 目前解决方法
使用 useTransition，将 onChange 事件中的操作标记为低优先级的任务，使 react 能优先处理用户输入，避免中文输入状态被打断。