### PR TITLE
refactor(builtinService): 侧边栏切换功能重构

### DIFF
--- a/src/controller/extension.ts
+++ b/src/controller/extension.ts
@@ -12,7 +12,6 @@ import { SelectColorThemeAction } from 'mo/monaco/selectColorThemeAction';
 import { QuickAccessSettings } from 'mo/monaco/quickAccessSettingsAction';
 import { SelectLocaleAction } from 'mo/i18n/selectLocaleAction';
 import { CommandQuickSideBarViewAction } from 'mo/monaco/quickToggleSideBarAction';
-import { ID_SIDE_BAR } from 'mo/common/id';
 import { QuickTogglePanelAction } from 'mo/monaco/quickTogglePanelAction';
 import { QuickSelectAllAction } from 'mo/monaco/quickSelectAllAction';
 import { QuickCopyLineUp } from 'mo/monaco/quickCopyLineUp';
@@ -48,6 +47,7 @@ export class ExtensionController
             quickUndoAction,
             quickRedoAction,
             quickCreateFileAction,
+            quickToggleSideBarAction,
         } = this.builtinService.getModules();
         (
             [
@@ -55,7 +55,7 @@ export class ExtensionController
                 [quickSelectColorThemeAction, SelectColorThemeAction],
                 [quickAccessSettingsAction, QuickAccessSettings],
                 [quickSelectLocaleAction, SelectLocaleAction],
-                [ID_SIDE_BAR, CommandQuickSideBarViewAction],
+                [quickToggleSideBarAction, CommandQuickSideBarViewAction],
                 [quickTogglePanelAction, QuickTogglePanelAction],
                 [quickSelectAllAction, QuickSelectAllAction],
                 [quickCopyLineUpAction, QuickCopyLineUp],

--- a/src/monaco/quickToggleSideBarAction.ts
+++ b/src/monaco/quickToggleSideBarAction.ts
@@ -15,13 +15,13 @@ import {
     MenuBarService,
     SidebarService,
 } from 'mo/services';
-import { ID_SIDE_BAR } from 'mo/common/id';
 import type { UniqueId } from 'mo/common/types';
 import { Action2 } from 'mo/monaco/action';
 import { CATEGORIES, KeybindingWeight } from 'mo/monaco/common';
+import { constants } from 'mo/services/builtinService/const';
 
 export class CommandQuickSideBarViewAction extends Action2 {
-    static readonly ID = ID_SIDE_BAR;
+    static readonly ID = constants.ACTION_QUICK_TOGGLE_SIDE_BAR;
     static readonly LABEL = localize(
         'menu.showSideBar.label',
         'Toggle Side Bar Visibility'

--- a/src/services/builtinService/const.ts
+++ b/src/services/builtinService/const.ts
@@ -80,6 +80,7 @@ export const constants = {
     ACTION_QUICK_REDO: 'editor.action.redo',
     ACTION_QUICK_CREATE_FILE: 'workbench.action.quickCreateFile',
     ACTION_QUICK_CREATE_FOLDER: 'workbench.action.quickCreateFolder',
+    ACTION_QUICK_TOGGLE_SIDE_BAR: 'workbench.action.quickToggleSideBar',
     ACTION_QUICK_ACCESS_SETTINGS: 'workbench.action.quickAccessSettings',
     ACTION_SELECT_THEME: 'workbench.action.selectTheme',
     ACTION_SELECT_LOCALE: 'workbench.action.selectLocale',
@@ -696,6 +697,10 @@ export const modules = {
 
     quickTogglePanelAction: () => ({
         id: constants.MENU_VIEW_PANEL,
+    }),
+
+    quickToggleSideBarAction: () => ({
+        id: constants.ACTION_QUICK_ACCESS_SETTINGS,
     }),
 
     quickSelectAllAction: () => ({

--- a/src/services/builtinService/const.ts
+++ b/src/services/builtinService/const.ts
@@ -700,7 +700,7 @@ export const modules = {
     }),
 
     quickToggleSideBarAction: () => ({
-        id: constants.ACTION_QUICK_ACCESS_SETTINGS,
+        id: constants.ACTION_QUICK_TOGGLE_SIDE_BAR,
     }),
 
     quickSelectAllAction: () => ({


### PR DESCRIPTION
## Description

原来注册CommandQuickSideBarViewAction是依据ID_SIDE_BAR，这样是无法禁用CommandQuickSideBarViewAction的，但是在有些场景下是不需要这个action的。

通过添加quickToggleSideBarAction这个builtin module，使得通过经验builtin module达到禁用CommandQuickSideBarViewAction成为可能。

## Changes

- 将 ACTION_QUICK_CREATE_FOLDER常量添加到 const.ts 文件中
- 在 extension.ts 中导入新的常量并更新相关动作映射
- 修改 quickToggleSideBarAction.ts 中的 ID 引用，使用新常量替代原有值

