### PR TITLE
fix: update mock dev server api handling

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
             languageWorkers: ['editorWorkerService'],
         }),
         mockDevServerPlugin({
-            include: 'app/mock/**/*.mock.{ts,js,cjs,mjs,json,json5}',
+            include: 'mock/**/*.mock.{ts,js,cjs,mjs,json,json5}',
+            prefix: '^/api',
         }),
     ],
     optimizeDeps: {
@@ -26,10 +27,5 @@ export default defineConfig({
     },
     server: {
         cors: false,
-        proxy: {
-            '^/api': {
-                target: '',
-            },
-        },
     },
 });


### PR DESCRIPTION
## Description

 修复本地开发环境中 mock API 的匹配与代理配置问题。

<img width="1257" height="440" alt="image" src="https://github.com/user-attachments/assets/6ab7d5e3-4a6f-4914-a411-8446e00caafd" />

## Changes
  - 将 `mockDevServerPlugin` 的 mock 文件匹配路径从 `app/mock/**/*.mock.*` 调整为 `mock/**/*.mock.*`
  - 为 mock 插件增加 `/api` 请求前缀匹配
  - 移除 Vite dev server 中空 `target` 的 `/api` proxy 配置

## How Has This Been Tested?
  - 启动本地开发服务
  - 验证 `/api` 前缀请求可以被 mock dev server 正常处理

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
